### PR TITLE
Economic Dispatch formulation

### DIFF
--- a/exp/config.toml
+++ b/exp/config.toml
@@ -12,6 +12,12 @@ l          = 0.8                # Lower bound of base load factor
 u          = 1.05               # Upper bound of base load factor
 sigma      = 0.15               # Relative (multiplicative) noise level.
 
+[sampler.reserve]
+type   = "E2ELR"
+l      = 1.0
+u      = 2.0
+factor = 5.0
+
 
 [OPF]
 # OPF formulations to solve for each sample
@@ -25,6 +31,11 @@ type = "ACPPowerModel"
 solver.name = "Ipopt"
 solver.attributes.tol = 1e-6
 solver.attributes.linear_solver = "ma27"
+
+[OPF.ED]
+type = "EconomicDispatch"
+kwargs.soft_thermal_limit = true
+solver.name = "Mosek"
 
 [OPF.SOCWRConic]
 type = "SOCWRConicPowerModel"

--- a/src/OPFGenerator.jl
+++ b/src/OPFGenerator.jl
@@ -4,7 +4,6 @@ using LinearAlgebra
 using Random
 using StableRNGs
 using Distributions
-using LinearAlgebra
 
 using PowerModels
 const PM = PowerModels

--- a/src/OPFGenerator.jl
+++ b/src/OPFGenerator.jl
@@ -4,6 +4,7 @@ using LinearAlgebra
 using Random
 using StableRNGs
 using Distributions
+using LinearAlgebra
 
 using PowerModels
 const PM = PowerModels

--- a/src/opf/ed.jl
+++ b/src/opf/ed.jl
@@ -124,7 +124,7 @@ function build_opf(::Type{EconomicDispatch}, data::Dict{String,Any}, optimizer;
     
         Ag, Al, pd = _ptdf_terms_from_data(data; T=T)
 
-        model[:ptdf_flow] .= JuMP.@constraint(model, (model.ext[:PTDF] * Ag) * model[:pg] - model[:pf] .== (model.ext[:PTDF] * Al) * pd)
+        model[:ptdf_flow] .= JuMP.@constraint(model, (model.ext[:PTDF] * Ag) * model[:pg] - model[:pf] .== model.ext[:PTDF] * (Al * pd))
         model.ext[:tracked_branches] .= true
         model.ext[:ptdf_iterations] = -1
     end

--- a/src/opf/ed.jl
+++ b/src/opf/ed.jl
@@ -175,8 +175,7 @@ function update!(opf::OPFModel{EconomicDispatch}, data::Dict{String,Any})
         
         E = length(ref[:branch])
         
-        tracked = findall(opf.model.ext[:tracked_branches])
-        JuMP.delete.(opf.model, opf.model[:ptdf_flow][tracked])
+        JuMP.delete.(opf.model, opf.model[:ptdf_flow][opf.model.ext[:tracked_branches]])
         
         JuMP.unregister.(opf.model, :ptdf_flow)
         opf.model[:ptdf_flow] = Vector{JuMP.ConstraintRef}(undef, E)

--- a/src/opf/ed.jl
+++ b/src/opf/ed.jl
@@ -231,11 +231,6 @@ function solve!(opf::OPFModel{EconomicDispatch})
     Ag, Al, pd = _ptdf_terms_from_data(data)
     p_expr = Ag * model[:pg] - Al * pd
 
-    if !model.ext[:solve_metadata][:iterative_ptdf]
-        optimize!(opf.model, _differentiation_backend = MathOptSymbolicAD.DefaultBackend())
-        return
-    end
-
     solved = false
     niter = 0
     solve_time = 0.0

--- a/src/opf/ed.jl
+++ b/src/opf/ed.jl
@@ -174,6 +174,11 @@ function update!(opf::OPFModel{EconomicDispatch}, data::Dict{String,Any})
         opf.model.ext[:ptdf_iterations] = 0
         
         E = length(ref[:branch])
+        
+        tracked = findall(opf.model.ext[:tracked_branches])
+        JuMP.delete.(opf.model, opf.model[:ptdf_flow][tracked])
+        
+        JuMP.unregister.(opf.model, :ptdf_flow)
         opf.model[:ptdf_flow] = Vector{JuMP.ConstraintRef}(undef, E)
 
         opf.model.ext[:termination_info] = Dict{Symbol,Any}(

--- a/src/opf/ed.jl
+++ b/src/opf/ed.jl
@@ -67,7 +67,6 @@ function build_opf(::Type{EconomicDispatch}, data::Dict{String,Any}, optimizer;
     JuMP.@variable(model, rmin[g] <= r[g in 1:G] <= rmax[g])
     JuMP.@variable(model, pf[e in 1:E])
 
-    # for upper bounds, see https://github.com/AI4OPT/OPFGenerator/pull/64/files#r1529320645
     JuMP.@variable(model, δpb_surplus >= 0)
     JuMP.@variable(model, δpb_shortage >= 0)
     JuMP.@variable(model, δr_shortage >= 0)

--- a/src/opf/ed.jl
+++ b/src/opf/ed.jl
@@ -2,18 +2,25 @@ using SparseArrays
 
 mutable struct EconomicDispatch <: PM.AbstractPowerModel end
 
+const POWER_BALANCE_PENALTY = 350000.0
+const RESERVE_SHORTAGE_PENALTY = 110000.0
+const THERMAL_PENALTY = 150000.0
+const MAX_PTDF_ITERATIONS = 128
+const MAX_PTDF_PER_ITERATION = 5
+const ITERATIVE_PTDF_TOL = 1e-6
+
 function build_opf(::Type{EconomicDispatch}, data::Dict{String,Any}, optimizer;
     T=Float64,
     soft_power_balance::Bool=false,
     soft_reserve_requirement::Bool=false,
     soft_thermal_limit::Bool=false,
-    power_balance_penalty=350000.0,
-    reserve_shortage_penalty=110000.0,
-    thermal_penalty=150000.0,
+    power_balance_penalty=POWER_BALANCE_PENALTY,
+    reserve_shortage_penalty=RESERVE_SHORTAGE_PENALTY,
+    thermal_penalty=THERMAL_PENALTY,
     iterative_ptdf::Bool=true,
-    iterative_ptdf_tol=1e-6,
-    max_ptdf_iterations=10,
-    max_ptdf_per_iteration=5,
+    iterative_ptdf_tol=ITERATIVE_PTDF_TOL,
+    max_ptdf_iterations=MAX_PTDF_ITERATIONS,
+    max_ptdf_per_iteration=MAX_PTDF_PER_ITERATION,
 )
     # Cleanup and pre-process data
     PM.standardize_cost_terms!(data, order=2)

--- a/src/opf/ed.jl
+++ b/src/opf/ed.jl
@@ -311,6 +311,8 @@ function solve!(opf::OPFModel{EconomicDispatch})
     model.ext[:termination_info][:ptdf_iterations] = niter
     model.ext[:termination_info][:termination_status] = st
 
+    model.ext[:ptdf_pf] = pf_
+
     return
 end
 
@@ -377,7 +379,8 @@ function extract_result(opf::OPFModel{EconomicDispatch})
             )
         else
             sol["branch"]["$e"] = Dict(
-                "pf" => value(model[:pf][e]),
+                # "pf" => value(model[:pf][e]),
+                "pf" => model.ext[:ptdf_pf][e],
                 "df" => value(model[:δf][e]),
                 "mu_pf" => dual(model[:pf_lower_bound][e]) - dual(model[:pf_upper_bound][e]),
                 "mu_df" => dual(LowerBoundRef(model[:δf][e])) - (has_upper_bound(model[:δf][e]) ? dual(UpperBoundRef(model[:δf][e])) : 0.0),

--- a/src/opf/ed.jl
+++ b/src/opf/ed.jl
@@ -154,6 +154,21 @@ function update!(opf::OPFModel{EconomicDispatch}, data::Dict{String,Any})
 
     JuMP.set_lower_bound.(opf.model[:r], rmin)
     JuMP.set_upper_bound.(opf.model[:r], rmax)
+
+    if opf.model.ext[:solve_metadata][:iterative_ptdf]
+        opf.model.ext[:tracked_branches] .= false
+        opf.model.ext[:ptdf_iterations] = 0
+        
+        E = length(ref[:branch])
+        opf.model.ext[:ptdf_flow] = Vector{JuMP.ConstraintRef}(undef, E)
+
+        opf.model.ext[:termination_info] = Dict{Symbol,Any}(
+            :termination_status => nothing,
+            :primal_status => nothing,
+            :dual_status => nothing,
+            :solve_time => nothing,
+        )
+    end
     
     return nothing
 end

--- a/src/opf/ed.jl
+++ b/src/opf/ed.jl
@@ -311,6 +311,9 @@ function solve!(opf::OPFModel{EconomicDispatch})
     model.ext[:termination_info][:ptdf_iterations] = niter
     model.ext[:termination_info][:termination_status] = st
 
+    pg_ = value.(model[:pg])
+    p_ = Ag * pg_ - Al * pd
+    pf_ = model.ext[:PTDF] * p_
     model.ext[:ptdf_pf] = pf_
 
     return

--- a/src/opf/ed.jl
+++ b/src/opf/ed.jl
@@ -457,7 +457,6 @@ function export_ptdf(opf::OPFModel{EconomicDispatch}, filepath)
 end
 
 function export_ptdf(data::Dict{String,Any}, filepath)
-    PM.calc_thermal_limits!(data)
     PTDF = PM.calc_basic_ptdf_matrix(data)
 
     h5open(filepath, "w") do file

--- a/src/opf/ed.jl
+++ b/src/opf/ed.jl
@@ -112,9 +112,18 @@ function build_opf(::Type{EconomicDispatch}, data::Dict{String,Any}, optimizer;
     )
 
     model.ext[:PTDF] = PM.calc_basic_ptdf_matrix(data)
-    model[:ptdf_flow] = Vector{JuMP.ConstraintRef}(undef, E)
-    model.ext[:tracked_branches] = zeros(Bool, E)
-    model.ext[:ptdf_iterations] = 0
+    if iterative_ptdf
+        model[:ptdf_flow] = Vector{JuMP.ConstraintRef}(undef, E)
+        model.ext[:tracked_branches] = zeros(Bool, E)
+        model.ext[:ptdf_iterations] = 0
+    else
+        Ag, Al, pd = _ptdf_terms_from_data(data)
+
+        p_expr = Ag * model[:pg] - Al * pd
+        JuMP.@constraint(model, ptdf_flow, model[:pf] .== model.ext[:PTDF] * p_expr)
+        model.ext[:tracked_branches] = ones(Bool, E)
+        model.ext[:ptdf_iterations] = -1
+    end
 
     # Objective
 
@@ -165,7 +174,7 @@ function update!(opf::OPFModel{EconomicDispatch}, data::Dict{String,Any})
         opf.model.ext[:ptdf_iterations] = 0
         
         E = length(ref[:branch])
-        opf.model.ext[:ptdf_flow] = Vector{JuMP.ConstraintRef}(undef, E)
+        opf.model[:ptdf_flow] = Vector{JuMP.ConstraintRef}(undef, E)
 
         opf.model.ext[:termination_info] = Dict{Symbol,Any}(
             :termination_status => nothing,
@@ -173,21 +182,24 @@ function update!(opf::OPFModel{EconomicDispatch}, data::Dict{String,Any})
             :dual_status => nothing,
             :solve_time => nothing,
         )
+    else
+        Ag, Al, pd = _ptdf_terms_from_data(data)
+
+        p_expr = Ag * opf.model[:pg] - Al * pd
+        JuMP.delete(opf.model, opf.model[:ptdf_flow])
+        JuMP.unregister(opf.model, :ptdf_flow)
+        JuMP.@constraint(opf.model, ptdf_flow, opf.model[:pf] .== opf.model.ext[:PTDF] * p_expr)
     end
     
     return nothing
 end
 
-function solve!(opf::OPFModel{EconomicDispatch})
-    data = opf.data
-    model = opf.model
-    T = typeof(model).parameters[1]
-    tol = model.ext[:solve_metadata][:iterative_ptdf_tol]
-
+function _ptdf_terms_from_data(data; T=Float64)
     N = length(data["bus"])
     G = length(data["gen"])
-    E = length(data["branch"])
     L = length(data["load"])
+    E = length(data["branch"])
+
     Al = sparse(
         [data["load"]["$l"]["load_bus"] for l in 1:L],
         [l for l in 1:L],
@@ -205,13 +217,26 @@ function solve!(opf::OPFModel{EconomicDispatch})
     )
 
     pd = [data["load"]["$l"]["pd"] for l in 1:L]
-    rate_a = [data["branch"]["$e"]["rate_a"] for e in 1:E]
 
+    return Ag, Al, pd
+end
+
+function solve!(opf::OPFModel{EconomicDispatch})
+    data = opf.data
+    model = opf.model
+    T = typeof(model).parameters[1]
+    tol = model.ext[:solve_metadata][:iterative_ptdf_tol]
+
+    N = length(data["bus"])
+    G = length(data["gen"])
+    E = length(data["branch"])
+    L = length(data["load"])
+    rate_a = [data["branch"]["$e"]["rate_a"] for e in 1:E]
+    
+    Ag, Al, pd = _ptdf_terms_from_data(data)
     p_expr = Ag * model[:pg] - Al * pd
 
     if !model.ext[:solve_metadata][:iterative_ptdf]
-        # add entire PTDF
-        @constraint(model, model[:pf] .== model.ext[:PTDF] * p_expr)
         optimize!(opf.model, _differentiation_backend = MathOptSymbolicAD.DefaultBackend())
         return
     end

--- a/src/opf/ed.jl
+++ b/src/opf/ed.jl
@@ -170,7 +170,6 @@ function update!(opf::OPFModel{EconomicDispatch}, data::Dict{String,Any})
     JuMP.set_upper_bound.(opf.model[:r], rmax)
 
     if opf.model.ext[:solve_metadata][:iterative_ptdf]
-        opf.model.ext[:tracked_branches] .= false
         opf.model.ext[:ptdf_iterations] = 0
         
         E = length(ref[:branch])
@@ -186,6 +185,7 @@ function update!(opf::OPFModel{EconomicDispatch}, data::Dict{String,Any})
             :dual_status => nothing,
             :solve_time => nothing,
         )
+        opf.model.ext[:tracked_branches] .= false
     else
         Ag, Al, pd = _ptdf_terms_from_data(data; T=T)
 

--- a/src/opf/ed.jl
+++ b/src/opf/ed.jl
@@ -449,8 +449,16 @@ function export_ptdf(opf::OPFModel{EconomicDispatch}, filepath)
     model = opf.model
 
     PTDF = model.ext[:PTDF]
-    E = size(PTDF, 1)
-    N = size(PTDF, 2)
+
+    h5open(filepath, "w") do file
+        write(file, "PTDF", PTDF)
+    end
+    return nothing
+end
+
+function export_ptdf(data::Dict{String,Any}, filepath)
+    PM.calc_thermal_limits!(data)
+    PTDF = PM.calc_basic_ptdf_matrix(data)
 
     h5open(filepath, "w") do file
         write(file, "PTDF", PTDF)

--- a/src/opf/ed.jl
+++ b/src/opf/ed.jl
@@ -130,14 +130,9 @@ function build_opf(::Type{EconomicDispatch}, data::Dict{String,Any}, optimizer;
     costs = [ref[:gen][g]["cost"] for g in 1:G]
     l, u = extrema(costs[1] for (i, gen) in ref[:gen])
     (l == u == 0.0) || @warn "Data $(data["name"]) has quadratic cost terms; those terms are being ignored"
-    
-    reserve_costs = [get(ref[:gen][g], "reserve_cost", zeros(T, 3)) for g in 1:G]
-    l, u = extrema(reserve_costs[1] for g in 1:G)
-    (l == u == 0.0) || @warn "Data $(data["name"]) has quadratic reserve cost terms; those terms are being ignored"
 
     JuMP.@objective(model, Min,
         sum(costs[g][2] * pg[g] + costs[g][3] for g in 1:G) +
-        sum(reserve_costs[g][2] * r[g] + reserve_costs[g][3] for g in 1:G) +
         power_balance_penalty * δpb_surplus +
         power_balance_penalty * δpb_shortage +
         reserve_shortage_penalty * δr_shortage +

--- a/src/opf/ed.jl
+++ b/src/opf/ed.jl
@@ -190,7 +190,7 @@ function update!(opf::OPFModel{EconomicDispatch}, data::Dict{String,Any})
     else
         Ag, Al, pd = _ptdf_terms_from_data(data; T=T)
 
-        JuMP.set_normalized_rhs.(opf.model[:ptdf_flow], PTDF * Al * pd)
+        JuMP.set_normalized_rhs.(opf.model[:ptdf_flow], opf.model.ext[:PTDF] * Al * pd)
     end
     
     return nothing

--- a/src/opf/ed.jl
+++ b/src/opf/ed.jl
@@ -1,0 +1,457 @@
+using SparseArrays
+
+mutable struct EconomicDispatch <: PM.AbstractPowerModel end
+
+function build_opf(::Type{EconomicDispatch}, data::Dict{String,Any}, optimizer;
+    T=Float64,
+    soft_power_balance::Bool=false,
+    soft_reserve_requirement::Bool=false,
+    soft_thermal_limit::Bool=false,
+    power_balance_penalty=350000.0,
+    reserve_shortage_penalty=110000.0,
+    thermal_penalty=150000.0,
+    iterative_ptdf::Bool=true,
+    iterative_ptdf_tol=1e-6,
+    max_ptdf_iterations=10,
+    max_ptdf_per_iteration=5,
+)
+    # Cleanup and pre-process data
+    PM.standardize_cost_terms!(data, order=2)
+    PM.calc_thermal_limits!(data)
+    ref = PM.build_ref(data)[:it][:pm][:nw][0]
+
+    # Check that slack bus is unique
+    length(ref[:ref_buses]) == 1 || error("Data has $(length(ref[:ref_buses])) slack buses (expected 1).")
+    i0 = first(keys(ref[:ref_buses]))
+
+    power_balance_penalty >= 0.0 || error("EconomicDispatch option power_balance_penalty must be non-negative")
+    reserve_shortage_penalty >= 0.0 || error("EconomicDispatch option reserve_shortage_penalty must be non-negative")
+    thermal_penalty >= 0.0 || error("EconomicDispatch option transmission_penalty must be non-negative")
+    max_ptdf_iterations > 0 || error("EconomicDispatch option max_ptdf_iterations must be a positive integer")
+    max_ptdf_per_iteration > 0 || error("EconomicDispatch option max_ptdf_per_iteration must be a positive integer")
+
+    # Grab some data
+    N = length(ref[:bus])
+    G = length(ref[:gen])
+    E = length(data["branch"])
+    L = length(ref[:load])
+
+    pmin = [ref[:gen][g]["pmin"] for g in 1:G]
+    pmax = [ref[:gen][g]["pmax"] for g in 1:G]
+    PD = sum(ref[:load][l]["pd"] for l in 1:L)
+    pfmax = [data["branch"]["$e"]["rate_a"] for e in 1:E]
+
+    minimum_reserve = get(data, "minimum_reserve", 0.0)
+    rmin = (minimum_reserve > 0.0) ? [ref[:gen][g]["rmin"] for g in 1:G] : zeros(T, G)
+    rmax = (minimum_reserve > 0.0) ? [ref[:gen][g]["rmax"] for g in 1:G] : zeros(T, G)
+
+    model = JuMP.GenericModel{T}(optimizer)
+    model.ext[:opf_model] = EconomicDispatch  # for internal checks
+    model.ext[:solve_metadata] = Dict{Symbol,Any}(
+        :iterative_ptdf => iterative_ptdf,
+        :iterative_ptdf_tol => iterative_ptdf_tol,
+        :max_ptdf_iterations => max_ptdf_iterations,
+        :max_ptdf_per_iteration => max_ptdf_per_iteration,
+    )
+
+    # Variables
+
+    JuMP.@variable(model, pmin[g] <= pg[g in 1:G] <= pmax[g])
+    JuMP.@variable(model, rmin[g] <= r[g in 1:G] <= rmax[g])
+    JuMP.@variable(model, pf[e in 1:E])
+
+    # for upper bounds, see https://github.com/AI4OPT/OPFGenerator/pull/64/files#r1529320645
+    JuMP.@variable(model, δpb_surplus >= 0)
+    JuMP.@variable(model, δpb_shortage >= 0)
+    JuMP.@variable(model, δr_shortage >= 0)
+    JuMP.@variable(model, δf[1:E] >= 0)
+
+    JuMP.@constraint(model,
+        pf_lower_bound[e in 1:E],
+        pf[e] + δf[e] >= -pfmax[e] 
+    )
+    JuMP.@constraint(model,
+        pf_upper_bound[e in 1:E],
+        pf[e] - δf[e] <= pfmax[e] 
+    )
+
+    if !soft_power_balance
+        JuMP.set_upper_bound(δpb_surplus, 0)
+        JuMP.set_upper_bound(δpb_shortage, 0)
+    end
+
+    if !soft_reserve_requirement && minimum_reserve > 0.0
+        JuMP.set_upper_bound(δr_shortage, 0)
+    end
+
+    if !soft_thermal_limit
+        JuMP.set_upper_bound.(δf, 0)
+    end
+
+    # Constraints
+
+    JuMP.@constraint(model,
+        total_generation[g in 1:G],
+        pg[g] + r[g] <= pmax[g]
+    )
+
+    JuMP.@constraint(model,
+        power_balance,
+        sum(pg) + δpb_surplus - δpb_shortage == PD
+    )
+
+    JuMP.@constraint(model,
+        reserve_requirement,
+        sum(r) + δr_shortage >= minimum_reserve
+    )
+
+    model.ext[:PTDF] = PM.calc_basic_ptdf_matrix(data)
+    model[:ptdf_flow] = Vector{JuMP.ConstraintRef}(undef, E)
+    model.ext[:tracked_branches] = zeros(Bool, E)
+    model.ext[:ptdf_iterations] = 0
+
+    # Objective
+
+    c = [ref[:gen][g]["cost"][2] for g in 1:G]
+    q = [get!(ref[:gen][g], "reserve_cost", zeros(T, 3))[2] for g in 1:G]
+    
+    l, u = extrema(gen["cost"][1] for (i, gen) in ref[:gen])
+    (l == u == 0.0) || @warn "Data $(data["name"]) has quadratic cost terms; those terms are being ignored"
+    
+    l, u = extrema(gen["reserve_cost"][1] for (i, gen) in ref[:gen])
+    (l == u == 0.0) || @warn "Data $(data["name"]) has quadratic reserve cost terms; those terms are being ignored"
+
+    JuMP.@objective(model, Min,
+        sum(c[g]*pg[g] + ref[:gen][g]["cost"][3] for g in 1:G) +
+        sum(q[g]*r[g] + ref[:gen][g]["reserve_cost"][3] for g in 1:G) +
+        power_balance_penalty * δpb_surplus +
+        power_balance_penalty * δpb_shortage +
+        reserve_shortage_penalty * δr_shortage +
+        thermal_penalty * sum(δf)
+    )
+
+    return OPFModel{EconomicDispatch}(data, model)
+end
+
+function update!(opf::OPFModel{EconomicDispatch}, data::Dict{String,Any})
+    PM.standardize_cost_terms!(data, order=2)
+    PM.calc_thermal_limits!(data)
+    ref = PM.build_ref(data)[:it][:pm][:nw][0]
+
+    opf.data = data
+
+    L = length(ref[:load])
+    PD = sum(ref[:load][l]["pd"] for l in 1:L)
+
+    JuMP.set_normalized_rhs(opf.model[:power_balance], PD)
+
+    MRR = get(data, "minimum_reserve", 0.0)
+    JuMP.set_normalized_rhs(opf.model[:reserve_requirement], MRR)
+
+    G = length(ref[:gen])
+    rmin = (MRR > 0.0) ? [ref[:gen][g]["rmin"] for g in 1:G] : zeros(typeof(opf.model).parameters[1], G)
+    rmax = (MRR > 0.0) ? [ref[:gen][g]["rmax"] for g in 1:G] : zeros(typeof(opf.model).parameters[1], G)
+
+    JuMP.set_lower_bound.(opf.model[:r], rmin)
+    JuMP.set_upper_bound.(opf.model[:r], rmax)
+    
+    return nothing
+end
+
+function solve!(opf::OPFModel{EconomicDispatch})
+    data = opf.data
+    model = opf.model
+    T = typeof(model).parameters[1]
+    tol = model.ext[:solve_metadata][:iterative_ptdf_tol]
+    
+    if !model.ext[:solve_metadata][:iterative_ptdf]
+        optimize!(opf.model, _differentiation_backend = MathOptSymbolicAD.DefaultBackend())
+        return
+    end
+
+    N = length(data["bus"])
+    G = length(data["gen"])
+    E = length(data["branch"])
+    L = length(data["load"])
+    Al = sparse(
+        [data["load"]["$l"]["load_bus"] for l in 1:L],
+        [l for l in 1:L],
+        ones(T, L),
+        N,
+        L,
+    )
+
+    Ag = sparse(
+        [data["gen"]["$g"]["gen_bus"] for g in 1:G],
+        [g for g in 1:G],
+        ones(T, G),
+        N,
+        G,
+    )
+
+    pd = [data["load"]["$l"]["pd"] for l in 1:L]
+    rate_a = [data["branch"]["$e"]["rate_a"] for e in 1:E]
+
+    p_expr = Ag * model[:pg] - Al * pd
+
+    solved = false
+    niter = 0
+    solve_time = 0.0
+    model.ext[:termination_info] = Dict{Symbol,Any}(
+        :termination_status => nothing,
+        :primal_status => nothing,
+        :dual_status => nothing,
+        :solve_time => nothing,
+    )
+    st = nothing
+    solve_time = @elapsed while !solved && niter < model.ext[:solve_metadata][:max_ptdf_iterations]
+        optimize!(opf.model, _differentiation_backend = MathOptSymbolicAD.DefaultBackend())
+        
+        st = termination_status(model)
+        st ∈ (MOI.OPTIMAL, MOI.LOCALLY_SOLVED) || break
+
+        pg_ = value.(model[:pg])
+        p_ = Ag * pg_ - Al * pd
+        pf_ = model.ext[:PTDF] * p_
+
+        n_violated = 0
+        for e in 1:E
+            if (model.ext[:tracked_branches][e]) || (-rate_a[e] - tol <= pf_[e] <= rate_a[e] + tol)
+                continue
+            end
+
+            n_violated += 1
+            if n_violated <= model.ext[:solve_metadata][:max_ptdf_per_iteration]
+                model[:ptdf_flow][e] = JuMP.@constraint(
+                    model,
+                    model[:pf][e] == dot(model.ext[:PTDF][e, :], p_expr)
+                )
+                model.ext[:tracked_branches][e] = true
+            end
+        end
+        solved = n_violated == 0
+        niter += 1
+    end
+
+    if niter == model.ext[:solve_metadata][:max_ptdf_iterations]
+        model.ext[:termination_info] = Dict{Symbol,Any}(
+            :primal_status => MOI.INFEASIBLE_POINT,
+            :dual_status => MOI.FEASIBLE_POINT,
+        )
+        st = MOI.ITERATION_LIMIT
+    elseif st == MOI.TIME_LIMIT
+        model.ext[:termination_info] = Dict{Symbol,Any}(
+            :primal_status => MOI.INFEASIBLE_POINT,
+            :dual_status => MOI.FEASIBLE_POINT,
+        )
+    elseif st ∈ (MOI.INFEASIBLE, MOI.LOCALLY_INFEASIBLE)
+        model.ext[:termination_info] = Dict{Symbol,Any}(
+            :primal_status => MOI.UNKNOWN_RESULT_STATUS,
+            :dual_status => MOI.INFEASIBILITY_CERTIFICATE,
+        )
+    elseif st == MOI.DUAL_INFEASIBLE
+        model.ext[:termination_info] = Dict{Symbol,Any}(
+            :primal_status => MOI.INFEASIBILITY_CERTIFICATE,
+            :dual_status => MOI.UNKNOWN_RESULT_STATUS,
+        )
+    elseif st ∈ (MOI.OPTIMAL, MOI.LOCALLY_SOLVED)
+        model.ext[:termination_info] = Dict{Symbol,Any}(
+            :primal_status => MOI.FEASIBLE_POINT,
+            :dual_status => MOI.FEASIBLE_POINT,
+        )
+    else
+        model.ext[:termination_info] = Dict{Symbol,Any}(
+            :primal_status => MOI.UNKNOWN_RESULT_STATUS,
+            :dual_status => MOI.UNKNOWN_RESULT_STATUS,
+        )
+    end
+
+    model.ext[:termination_info][:solve_time] = solve_time
+    model.ext[:termination_info][:ptdf_iterations] = niter
+    model.ext[:termination_info][:termination_status] = st
+
+    return
+end
+
+function extract_result(opf::OPFModel{EconomicDispatch})
+    data = opf.data
+    model = opf.model
+
+    ref = PM.build_ref(data)[:it][:pm][:nw][0]
+    N = length(ref[:bus])
+    G = length(ref[:gen])
+    E = length(data["branch"])
+
+    res = Dict{String,Any}()
+    res["opf_model"] = string(model.ext[:opf_model])
+    res["objective"] = JuMP.objective_value(model)
+    res["objective_lb"] = -Inf
+    res["optimizer"] = JuMP.solver_name(model)
+
+    res["solve_metadata"] = model.ext[:solve_metadata]
+    if model.ext[:solve_metadata][:iterative_ptdf]
+        tinfo = model.ext[:termination_info]
+        res["termination_status"] = tinfo[:termination_status]
+        res["primal_status"] = tinfo[:primal_status]
+        res["dual_status"] = tinfo[:dual_status]
+        res["solve_time"] = tinfo[:solve_time]
+        res["ptdf_iterations"] = tinfo[:ptdf_iterations]
+    else
+        res["termination_status"] = JuMP.termination_status(model)
+        res["primal_status"] = JuMP.primal_status(model)
+        res["dual_status"] = JuMP.dual_status(model)
+        res["solve_time"] = JuMP.solve_time(model)
+    end
+    res["minimum_reserve"] = get(data, "minimum_reserve", 0.0)
+
+    res["solution"] = sol = Dict{String,Any}()
+
+    sol["per_unit"] = get(data, "per_unit", false)
+    sol["baseMVA"]  = get(data, "baseMVA", 100.0)
+
+    sol["gen"] = Dict{String,Any}()
+    for g in 1:G
+        sol["gen"]["$g"] = Dict(
+            "pg" => value(model[:pg][g]),
+            "r" => value(model[:r][g]),
+            "rmin" => get(data["gen"]["$g"], "rmin", 0.0),
+            "rmax" => get(data["gen"]["$g"], "rmax", 0.0),
+
+            "mu_pg" => dual(LowerBoundRef(model[:pg][g])) - dual(UpperBoundRef(model[:pg][g])),
+            "mu_r" => dual(LowerBoundRef(model[:r][g])) - dual(UpperBoundRef(model[:r][g])),
+
+            "mu_total_generation" => dual(model[:total_generation][g]),
+        )
+    end
+
+    sol["branch"] = Dict{String,Any}()
+    for e in 1:E
+        if data["branch"]["$e"]["br_status"] == 0
+            sol["branch"]["$e"] = Dict(
+                "pf" => 0,
+                "df" => 0,
+                "mu_pf" => 0,
+                "mu_df" => 0,
+                "lam_ptdf" => 0,
+            )
+        else
+            sol["branch"]["$e"] = Dict(
+                "pf" => value(model[:pf][e]),
+                "df" => value(model[:δf][e]),
+                "mu_pf" => dual(model[:pf_lower_bound][e]) - dual(model[:pf_upper_bound][e]),
+                "mu_df" => dual(LowerBoundRef(model[:δf][e])) - (has_upper_bound(model[:δf][e]) ? dual(UpperBoundRef(model[:δf][e])) : 0.0),
+                "lam_ptdf" => isdefined(model[:ptdf_flow], e) ? dual(model[:ptdf_flow][e]) : 0.0,
+            )
+        end
+    end
+
+    sol["singleton"] = Dict{String,Any}(
+        "dpb_surplus" => value(model[:δpb_surplus]),
+        "dpb_shortage" => value(model[:δpb_shortage]),
+        "dr_shortage" => value(model[:δr_shortage]),
+
+        "mu_dpb_surplus" => dual(LowerBoundRef(model[:δpb_surplus])) - (has_upper_bound(model[:δpb_surplus]) ? dual(UpperBoundRef(model[:δpb_surplus])) : 0.0),
+        "mu_dpb_shortage" => dual(LowerBoundRef(model[:δpb_shortage])) - (has_upper_bound(model[:δpb_shortage]) ? dual(UpperBoundRef(model[:δpb_shortage])) : 0.0),
+        "mu_dr_shortage" => dual(LowerBoundRef(model[:δr_shortage])) - (has_upper_bound(model[:δr_shortage]) ? dual(UpperBoundRef(model[:δr_shortage])) : 0.0),
+
+        "mu_power_balance" => dual(model[:power_balance]),
+        "mu_reserve_requirement" => dual(model[:reserve_requirement]),
+    )
+
+    return res
+end
+
+function json2h5(::Type{EconomicDispatch}, res)
+    sol = res["solution"]
+
+    E = length(sol["branch"])
+    G = length(sol["gen"])
+
+    res_h5 = Dict{String,Any}(
+        "meta" => Dict{String,Any}(
+            "termination_status" => string(res["termination_status"]),
+            "primal_status" => string(res["primal_status"]),
+            "dual_status" => string(res["dual_status"]),
+            "solve_time" => res["solve_time"],
+        ),
+    )
+
+    res_h5["primal"] = pres_h5 = Dict{String,Any}(
+        "pg" => zeros(Float64, G),
+        "r" => zeros(Float64, G),
+        "pf" => zeros(Float64, E),
+        "rmin" => zeros(Float64, G),
+        "rmax" => zeros(Float64, G),
+
+        "df" => zeros(Float64, E),
+        "dpb_surplus" => 0,
+        "dpb_shortage" => 0,
+        "dr_shortage" => 0,
+    )
+
+    res_h5["dual"] = dres_h5 = Dict{String,Any}(
+        "mu_pg" => zeros(Float64, G),
+        "mu_r" => zeros(Float64, G),
+        "mu_total_generation" => zeros(Float64, G),
+        "mu_pf" => zeros(Float64, E),
+        "mu_df" => zeros(Float64, E),
+        "lam_ptdf" => zeros(Float64, E),
+        "mu_dpb_surplus" => 0,
+        "mu_dpb_shortage" => 0,
+        "mu_dr_shortage" => 0,
+        "mu_power_balance" => 0,
+        "mu_reserve_requirement" => 0,
+    )
+
+    for g in 1:G
+        gsol = sol["gen"]["$g"]
+
+        pres_h5["pg"][g] = gsol["pg"]
+        pres_h5["r"][g] = gsol["r"]
+        pres_h5["rmin"][g] = gsol["rmin"]
+        pres_h5["rmax"][g] = gsol["rmax"]
+
+        dres_h5["mu_pg"][g] = gsol["mu_pg"]
+        dres_h5["mu_r"][g] = gsol["mu_r"]
+        dres_h5["mu_total_generation"][g] = gsol["mu_total_generation"]
+    end
+
+    for e in 1:E
+        brsol = sol["branch"]["$e"]
+
+        pres_h5["pf"][e] = brsol["pf"]
+        pres_h5["df"][e] = brsol["df"]
+
+        dres_h5["mu_pf"][e] = brsol["mu_pf"]
+        dres_h5["mu_df"][e] = brsol["mu_df"]
+        dres_h5["lam_ptdf"][e] = brsol["lam_ptdf"]
+    end
+
+    pres_h5["dpb_surplus"] = sol["singleton"]["dpb_surplus"]
+    pres_h5["dpb_shortage"] = sol["singleton"]["dpb_shortage"]
+    pres_h5["dr_shortage"] = sol["singleton"]["dr_shortage"]
+    pres_h5["minimum_reserve"] = res["minimum_reserve"]
+
+    dres_h5["mu_dpb_surplus"] = sol["singleton"]["mu_dpb_surplus"]
+    dres_h5["mu_dpb_shortage"] = sol["singleton"]["mu_dpb_shortage"]
+    dres_h5["mu_dr_shortage"] = sol["singleton"]["mu_dr_shortage"]
+    dres_h5["mu_power_balance"] = sol["singleton"]["mu_power_balance"]
+    dres_h5["mu_reserve_requirement"] = sol["singleton"]["mu_reserve_requirement"]
+
+    return res_h5
+
+end
+
+function export_ptdf(opf::OPFModel{EconomicDispatch}, filepath)
+    data = opf.data
+    model = opf.model
+
+    PTDF = model.ext[:PTDF]
+    E = size(PTDF, 1)
+    N = size(PTDF, 2)
+
+    h5open(filepath, "w") do file
+        write(file, "PTDF", PTDF)
+    end
+    return nothing
+end

--- a/src/opf/ed.jl
+++ b/src/opf/ed.jl
@@ -49,6 +49,8 @@ function build_opf(::Type{EconomicDispatch}, data::Dict{String,Any}, optimizer;
     pfmax = [data["branch"]["$e"]["rate_a"] for e in 1:E]
 
     minimum_reserve = get(data, "minimum_reserve", 0.0)
+    # if minimum reserve is zero, rmin = rmax = 0 to fix the reserve variables to zero.
+    # otherwise, rmin and rmax must be present in the data (not standard in PGLib)
     rmin = (minimum_reserve > 0.0) ? [ref[:gen][g]["rmin"] for g in 1:G] : zeros(T, G)
     rmax = (minimum_reserve > 0.0) ? [ref[:gen][g]["rmax"] for g in 1:G] : zeros(T, G)
 

--- a/src/opf/ed.jl
+++ b/src/opf/ed.jl
@@ -124,8 +124,8 @@ function build_opf(::Type{EconomicDispatch}, data::Dict{String,Any}, optimizer;
     
         Ag, Al, pd = _ptdf_terms_from_data(data; T=T)
 
-        JuMP.@constraint(model, ptdf_flow, (model.ext[:PTDF] * Ag) * model[:pg] - model[:pf] .== (model.ext[:PTDF] * Al) * pd)
-        model.ext[:tracked_branches] = ones(Bool, E)
+        model[:ptdf_flow] .= JuMP.@constraint(model, (model.ext[:PTDF] * Ag) * model[:pg] - model[:pf] .== (model.ext[:PTDF] * Al) * pd)
+        model.ext[:tracked_branches] .= true
         model.ext[:ptdf_iterations] = -1
     end
 

--- a/src/opf/opf.jl
+++ b/src/opf/opf.jl
@@ -7,12 +7,14 @@ end
 
 include("acp.jl")      # ACPPowerModel
 include("dcp.jl")      # DCPPowerModel
+include("ed.jl")       # EconomicDispatch
 include("socwr.jl")    # SOCWRPowerModel & SOCWRConicPowerModel
 
 # Contains a list of all supported OPF models
 const SUPPORTED_OPF_MODELS = Type{<:AbstractPowerModel}[
     PowerModels.ACPPowerModel,
     PowerModels.DCPPowerModel,
+    EconomicDispatch,
     PowerModels.SOCWRPowerModel,
     PowerModels.SOCWRConicPowerModel,
 ]
@@ -22,6 +24,7 @@ const SUPPORTED_OPF_MODELS = Type{<:AbstractPowerModel}[
 const OPF2TYPE = Dict{String,Type{<:AbstractPowerModel}}(
     "ACPPowerModel" => PowerModels.ACPPowerModel,
     "DCPPowerModel" => PowerModels.DCPPowerModel,
+    "EconomicDispatch" => EconomicDispatch,
     "SOCWRPowerModel" => PowerModels.SOCWRPowerModel,
     "SOCWRConicPowerModel" => PowerModels.SOCWRConicPowerModel,
 )

--- a/src/sampler/reserve.jl
+++ b/src/sampler/reserve.jl
@@ -11,7 +11,7 @@ Samples reserve requirements following the procedure below:
 2. Compute the upper bound of reserve requirements for each generator as `rmax = α * (pmax - pmin)`.
 3. Fix the lower bound of reserve requirement per generator to zero.
 
-The parameter `α` is a scaling factor that determines each generator's maximum reserve_cost
+The parameter `α` is a scaling factor that determines each generator's maximum reserve
     capacity. It is the `factor` parameter times the ratio of the largest generator's capacity
     to the sum of all generators' dispatchable capacity.
 

--- a/src/sampler/reserve.jl
+++ b/src/sampler/reserve.jl
@@ -10,6 +10,7 @@ Samples reserve requirements following the procedure below:
 1. Sample a minimum reserve requirement `MRR` from a uniform distribution `U(lb, ub)` (`mrr_dist`).
 2. Compute the upper bound of reserve requirements for each generator as `rmax = α * (pmax - pmin)`.
 3. Fix the lower bound of reserve requirement per generator to zero.
+4. Fix the reserve cost of each generator to zero.
 
 The parameter `α` is a scaling factor that determines each generator's maximum reserve
     capacity. It is the `factor` parameter times the ratio of the largest generator's capacity
@@ -33,7 +34,8 @@ function Random.rand(rng::AbstractRNG, rs::E2ELRReserveScaler)
     α = rs.factor * pmax / sum(pg_ranges)
     rmax = α .* pg_ranges
     rmin = zeros(Float64, length(rmax))
-    return MRR, rmin, rmax
+    reserve_cost = zeros(Float64, length(rmax), 3)
+    return MRR, rmin, rmax, reserve_cost
 end
 
 
@@ -42,7 +44,7 @@ struct NullReserveScaler <: AbstractReserveSampler
 end
 
 function Random.rand(rng::AbstractRNG, rs::NullReserveScaler)
-    return 0.0, zeros(Float64, rs.n_gen), zeros(Float64, rs.n_gen)
+    return 0.0, zeros(Float64, rs.n_gen), zeros(Float64, rs.n_gen), zeros(Float64, rs.n_gen, 3)
 end
 
 function ReserveScaler(data::Dict, options::Dict)

--- a/src/sampler/reserve.jl
+++ b/src/sampler/reserve.jl
@@ -30,7 +30,7 @@ function Random.rand(rng::AbstractRNG, rs::E2ELRReserveScaler)
     # generate reserve requirements
     pg_ranges = max.(0.0, rs.pg_max .- rs.pg_min)
     α = rs.factor * pmax / sum(pg_ranges)
-    rmax = α * pg_ranges
+    rmax = α .* pg_ranges
     rmin = zeros(Float64, length(rmax))
     return MRR, rmin, rmax
 end

--- a/src/sampler/reserve.jl
+++ b/src/sampler/reserve.jl
@@ -1,0 +1,103 @@
+import Distributions: length, eltype, _rand!
+
+abstract type AbstractReserveSampler end
+
+"""
+    E2ELRReserveScaler{U,F}
+
+Samples reserve requirements following the procedure below:
+
+1. Sample a minimum reserve requirement `MRR` from a uniform distribution `U(lb, ub)`.
+2. Compute the upper bound of reserve requirements for each generator as `rmax = α * (pmax - pmin)`.
+3. Fix the lower bound of reserve requirement per generator to zero.
+
+The parameter `α` is a scaling factor that determines the total reserve requirement
+    as a multiple of the maximum power range of all generators.
+
+"""
+struct E2ELRReserveScaler <: AbstractReserveSampler
+    mrr_dist::Uniform
+    factor::Float64
+    pg_min::Vector{Float64}
+    pg_max::Vector{Float64}
+end
+
+function Random.rand(rng::AbstractRNG, rs::E2ELRReserveScaler)
+    # generate MRR
+    pmax = maximum(rs.pg_max)
+    MRR = rand(rng, rs.mrr_dist) * pmax
+
+    # generate reserve requirements
+    pg_ranges = max.(0.0, rs.pg_max .- rs.pg_min)
+    α = rs.factor * pmax / sum(pg_ranges)
+    rmax = α * pg_ranges
+    rmin = zeros(Float64, length(rmax))
+    return MRR, rmin, rmax
+end
+
+"""
+    UCjlReserveScaler
+
+Samples reserve requirements following the procedure below:
+
+1. Compute minimum reserve requirement `MRR` by scaling the reference power demand
+    with the minimum reserve fraction.
+
+2. Compute the upper bound of reserve requirements for each generator by scaling
+    the active generation upper bound with the maximum reserve fraction.
+
+NOTE: This reserve scaler itself does not use any random variables to compute
+    reserve requirements. However, it depends on the active load and generation
+    upper bound, which themselves may vary for each sample.
+
+"""
+struct UCjlReserveScaler <: AbstractReserveSampler
+    min_frac::Float64
+    max_frac::Float64
+    pd_ref::Vector{Float64}
+    pg_max::Vector{Float64}
+end
+
+function Random.rand(rng::AbstractRNG, rs::UCjlReserveScaler)
+    # generate MRR
+    MRR = rs.min_frac * sum(rs.pd_ref)
+
+    rmax = rs.max_frac .* rs.pg_max
+    rmin = zeros(Float64, length(rmax))
+
+    return MRR, rmin, rmax
+end
+
+function ReserveScaler(data::Dict, options::Dict)
+    get(data, "basic_network", false) || error(
+        """Invalid data: network data must be in basic format.
+        Call `make_basic_network(data)` before calling this function"""
+    )
+
+    reserve_type = get(options, "type", "")
+    if reserve_type == "E2ELR"
+        l = options["l"]
+        u = options["u"]
+        factor = get(options, "factor", 5.0)
+        mrr_dist = Uniform(l, u)
+
+        pg_min = [gen["pmin"] for (id, gen) in data["gen"]]
+        pg_max = [gen["pmax"] for (id, gen) in data["gen"]]
+
+        return E2ELRReserveScaler(mrr_dist, factor, pg_min, pg_max)
+
+    elseif reserve_type == "UCjl"
+        min_frac = get(options, "min_frac", 0.1)
+        max_frac = get(options, "max_frac", 0.1)
+
+        pd_ref = [data["load"]["$i"]["pd"] for i in 1:length(data["load"])]
+        pg_max = [gen["pmax"] for (id, gen) in data["gen"]]
+
+        @warn "When using the UCjl reserve scaler, the minimum reserve requirement (MRR)
+             depends on the total active load, which typically varies per sample. Proceed with caution."
+
+        return UCjlReserveScaler(min_frac, max_frac, pd_ref, pg_max)
+    else
+        error("Invalid noise type: $(reserve_type).\nOnly \"E2ELR\" and \"UCjl\" are supported.")
+    end
+end

--- a/src/sampler/reserve.jl
+++ b/src/sampler/reserve.jl
@@ -98,6 +98,6 @@ function ReserveScaler(data::Dict, options::Dict)
 
     #     return UCjlReserveScaler(min_frac, max_frac, pd_ref, pg_max)
     else
-        error("Invalid noise type: $(reserve_type).\nOnly \"E2ELR\" and \"UCjl\" are supported.")
+        error("Invalid noise type: $(reserve_type).\nOnly \"E2ELR\" is supported.")
     end
 end

--- a/src/sampler/reserve.jl
+++ b/src/sampler/reserve.jl
@@ -3,16 +3,17 @@ import Distributions: length, eltype, _rand!
 abstract type AbstractReserveSampler end
 
 """
-    E2ELRReserveScaler{U,F}
+    E2ELRReserveScaler
 
 Samples reserve requirements following the procedure below:
 
-1. Sample a minimum reserve requirement `MRR` from a uniform distribution `U(lb, ub)`.
+1. Sample a minimum reserve requirement `MRR` from a uniform distribution `U(lb, ub)` (`mrr_dist`).
 2. Compute the upper bound of reserve requirements for each generator as `rmax = α * (pmax - pmin)`.
 3. Fix the lower bound of reserve requirement per generator to zero.
 
-The parameter `α` is a scaling factor that determines the total reserve requirement
-    as a multiple of the maximum power range of all generators.
+The parameter `α` is a scaling factor that determines each generator's maximum reserve_cost
+    capacity. It is the `factor` parameter times the ratio of the largest generator's capacity
+    to the sum of all generators' dispatchable capacity.
 
 """
 struct E2ELRReserveScaler <: AbstractReserveSampler

--- a/src/sampler/reserve.jl
+++ b/src/sampler/reserve.jl
@@ -35,39 +35,6 @@ function Random.rand(rng::AbstractRNG, rs::E2ELRReserveScaler)
     return MRR, rmin, rmax
 end
 
-# """
-#     UCjlReserveScaler
-
-# Samples reserve requirements following the procedure below:
-
-# 1. Compute minimum reserve requirement `MRR` by scaling the reference power demand
-#     with the minimum reserve fraction.
-
-# 2. Compute the upper bound of reserve requirements for each generator by scaling
-#     the active generation upper bound with the maximum reserve fraction.
-
-# NOTE: This reserve scaler itself does not use any random variables to compute
-#     reserve requirements. However, it depends on the active load and generation
-#     upper bound, which themselves may vary for each sample.
-
-# """
-# struct UCjlReserveScaler <: AbstractReserveSampler
-#     min_frac::Float64
-#     max_frac::Float64
-#     pd_ref::Vector{Float64}
-#     pg_max::Vector{Float64}
-# end
-
-# function Random.rand(rng::AbstractRNG, rs::UCjlReserveScaler)
-#     # generate MRR
-#     MRR = rs.min_frac * sum(rs.pd_ref)
-
-#     rmax = rs.max_frac .* rs.pg_max
-#     rmin = zeros(Float64, length(rmax))
-
-#     return MRR, rmin, rmax
-# end
-
 function ReserveScaler(data::Dict, options::Dict)
     get(data, "basic_network", false) || error(
         """Invalid data: network data must be in basic format.
@@ -85,18 +52,6 @@ function ReserveScaler(data::Dict, options::Dict)
         pg_max = [gen["pmax"] for (id, gen) in data["gen"]]
 
         return E2ELRReserveScaler(mrr_dist, factor, pg_min, pg_max)
-
-    # elseif reserve_type == "UCjl"
-    #     min_frac = get(options, "min_frac", 0.1)
-    #     max_frac = get(options, "max_frac", 0.1)
-
-    #     pd_ref = [data["load"]["$i"]["pd"] for i in 1:length(data["load"])]
-    #     pg_max = [gen["pmax"] for (id, gen) in data["gen"]]
-
-    #     @warn "When using the UCjl reserve scaler, the minimum reserve requirement (MRR)
-    #          depends on the total active load, which typically varies per sample. Proceed with caution."
-
-    #     return UCjlReserveScaler(min_frac, max_frac, pd_ref, pg_max)
     else
         error("Invalid noise type: $(reserve_type).\nOnly \"E2ELR\" is supported.")
     end

--- a/src/sampler/reserve.jl
+++ b/src/sampler/reserve.jl
@@ -34,8 +34,7 @@ function Random.rand(rng::AbstractRNG, rs::E2ELRReserveScaler)
     α = rs.factor * pmax / sum(pg_ranges)
     rmax = α .* pg_ranges
     rmin = zeros(Float64, length(rmax))
-    reserve_cost = zeros(Float64, length(rmax), 3)
-    return MRR, rmin, rmax, reserve_cost
+    return MRR, rmin, rmax
 end
 
 
@@ -44,7 +43,7 @@ struct NullReserveScaler <: AbstractReserveSampler
 end
 
 function Random.rand(rng::AbstractRNG, rs::NullReserveScaler)
-    return 0.0, zeros(Float64, rs.n_gen), zeros(Float64, rs.n_gen), zeros(Float64, rs.n_gen, 3)
+    return 0.0, zeros(Float64, rs.n_gen), zeros(Float64, rs.n_gen)
 end
 
 function ReserveScaler(data::Dict, options::Dict)

--- a/src/sampler/reserve.jl
+++ b/src/sampler/reserve.jl
@@ -35,38 +35,38 @@ function Random.rand(rng::AbstractRNG, rs::E2ELRReserveScaler)
     return MRR, rmin, rmax
 end
 
-"""
-    UCjlReserveScaler
+# """
+#     UCjlReserveScaler
 
-Samples reserve requirements following the procedure below:
+# Samples reserve requirements following the procedure below:
 
-1. Compute minimum reserve requirement `MRR` by scaling the reference power demand
-    with the minimum reserve fraction.
+# 1. Compute minimum reserve requirement `MRR` by scaling the reference power demand
+#     with the minimum reserve fraction.
 
-2. Compute the upper bound of reserve requirements for each generator by scaling
-    the active generation upper bound with the maximum reserve fraction.
+# 2. Compute the upper bound of reserve requirements for each generator by scaling
+#     the active generation upper bound with the maximum reserve fraction.
 
-NOTE: This reserve scaler itself does not use any random variables to compute
-    reserve requirements. However, it depends on the active load and generation
-    upper bound, which themselves may vary for each sample.
+# NOTE: This reserve scaler itself does not use any random variables to compute
+#     reserve requirements. However, it depends on the active load and generation
+#     upper bound, which themselves may vary for each sample.
 
-"""
-struct UCjlReserveScaler <: AbstractReserveSampler
-    min_frac::Float64
-    max_frac::Float64
-    pd_ref::Vector{Float64}
-    pg_max::Vector{Float64}
-end
+# """
+# struct UCjlReserveScaler <: AbstractReserveSampler
+#     min_frac::Float64
+#     max_frac::Float64
+#     pd_ref::Vector{Float64}
+#     pg_max::Vector{Float64}
+# end
 
-function Random.rand(rng::AbstractRNG, rs::UCjlReserveScaler)
-    # generate MRR
-    MRR = rs.min_frac * sum(rs.pd_ref)
+# function Random.rand(rng::AbstractRNG, rs::UCjlReserveScaler)
+#     # generate MRR
+#     MRR = rs.min_frac * sum(rs.pd_ref)
 
-    rmax = rs.max_frac .* rs.pg_max
-    rmin = zeros(Float64, length(rmax))
+#     rmax = rs.max_frac .* rs.pg_max
+#     rmin = zeros(Float64, length(rmax))
 
-    return MRR, rmin, rmax
-end
+#     return MRR, rmin, rmax
+# end
 
 function ReserveScaler(data::Dict, options::Dict)
     get(data, "basic_network", false) || error(
@@ -86,17 +86,17 @@ function ReserveScaler(data::Dict, options::Dict)
 
         return E2ELRReserveScaler(mrr_dist, factor, pg_min, pg_max)
 
-    elseif reserve_type == "UCjl"
-        min_frac = get(options, "min_frac", 0.1)
-        max_frac = get(options, "max_frac", 0.1)
+    # elseif reserve_type == "UCjl"
+    #     min_frac = get(options, "min_frac", 0.1)
+    #     max_frac = get(options, "max_frac", 0.1)
 
-        pd_ref = [data["load"]["$i"]["pd"] for i in 1:length(data["load"])]
-        pg_max = [gen["pmax"] for (id, gen) in data["gen"]]
+    #     pd_ref = [data["load"]["$i"]["pd"] for i in 1:length(data["load"])]
+    #     pg_max = [gen["pmax"] for (id, gen) in data["gen"]]
 
-        @warn "When using the UCjl reserve scaler, the minimum reserve requirement (MRR)
-             depends on the total active load, which typically varies per sample. Proceed with caution."
+    #     @warn "When using the UCjl reserve scaler, the minimum reserve requirement (MRR)
+    #          depends on the total active load, which typically varies per sample. Proceed with caution."
 
-        return UCjlReserveScaler(min_frac, max_frac, pd_ref, pg_max)
+    #     return UCjlReserveScaler(min_frac, max_frac, pd_ref, pg_max)
     else
         error("Invalid noise type: $(reserve_type).\nOnly \"E2ELR\" and \"UCjl\" are supported.")
     end

--- a/src/sampler/reserve.jl
+++ b/src/sampler/reserve.jl
@@ -16,7 +16,7 @@ The parameter `α` is a scaling factor that determines the total reserve require
 
 """
 struct E2ELRReserveScaler <: AbstractReserveSampler
-    mrr_dist::Uniform
+    mrr_dist::Uniform{Float64}
     factor::Float64
     pg_min::Vector{Float64}
     pg_max::Vector{Float64}

--- a/src/sampler/sampler.jl
+++ b/src/sampler/sampler.jl
@@ -43,8 +43,8 @@ function Random.rand!(rng::AbstractRNG, s::SimpleOPFSampler, data::Dict)
     pd, qd = rand(rng, s.load_sampler)
     _set_loads!(data, pd, qd)
 
-    MRR, rmin, rmax, reserve_cost = rand(rng, s.reserve_sampler)
-    _set_reserve!(data, MRR, rmin, rmax, reserve_cost)
+    MRR, rmin, rmax = rand(rng, s.reserve_sampler)
+    _set_reserve!(data, MRR, rmin, rmax)
 
     return data
 end
@@ -63,7 +63,7 @@ function _set_loads!(data, pd, qd)
     return nothing
 end
 
-function _set_reserve!(data, MRR, rmin, rmax, reserve_cost)
+function _set_reserve!(data, MRR, rmin, rmax)
     G = length(data["gen"])
     length(rmin) == G || throw(DimensionMismatch())
     length(rmax) == G || throw(DimensionMismatch())
@@ -72,7 +72,6 @@ function _set_reserve!(data, MRR, rmin, rmax, reserve_cost)
         gdat = data["gen"]["$i"]
         gdat["rmin"] = rmin[i]
         gdat["rmax"] = rmax[i]
-        gdat["reserve_cost"] = reserve_cost[i, :]
     end
 
     data["minimum_reserve"] = MRR

--- a/src/sampler/sampler.jl
+++ b/src/sampler/sampler.jl
@@ -43,8 +43,8 @@ function Random.rand!(rng::AbstractRNG, s::SimpleOPFSampler, data::Dict)
     pd, qd = rand(rng, s.load_sampler)
     _set_loads!(data, pd, qd)
 
-    MRR, rmin, rmax = rand(rng, s.reserve_sampler)
-    _set_reserve!(data, MRR, rmin, rmax)
+    MRR, rmin, rmax, reserve_cost = rand(rng, s.reserve_sampler)
+    _set_reserve!(data, MRR, rmin, rmax, reserve_cost)
 
     return data
 end
@@ -63,7 +63,7 @@ function _set_loads!(data, pd, qd)
     return nothing
 end
 
-function _set_reserve!(data, MRR, rmin, rmax)
+function _set_reserve!(data, MRR, rmin, rmax, reserve_cost)
     G = length(data["gen"])
     length(rmin) == G || throw(DimensionMismatch())
     length(rmax) == G || throw(DimensionMismatch())
@@ -72,6 +72,7 @@ function _set_reserve!(data, MRR, rmin, rmax)
         gdat = data["gen"]["$i"]
         gdat["rmin"] = rmin[i]
         gdat["rmax"] = rmax[i]
+        gdat["reserve_cost"] = reserve_cost[i, :]
     end
 
     data["minimum_reserve"] = MRR

--- a/src/sampler/sampler.jl
+++ b/src/sampler/sampler.jl
@@ -20,11 +20,8 @@ function SimpleOPFSampler(data::Dict, config::Dict)
     load_sampler = LoadScaler(data, config["load"])
 
     # Instantiate reserve sampler
-    if haskey(config, "reserve")
-        reserve_sampler = ReserveScaler(data, config["reserve"])
-    else
-        reserve_sampler = nothing
-    end 
+    get!(config, "reserve", Dict())
+    reserve_sampler = ReserveScaler(data, config["reserve"])
 
     return SimpleOPFSampler(data, load_sampler, reserve_sampler)
 end
@@ -46,10 +43,8 @@ function Random.rand!(rng::AbstractRNG, s::SimpleOPFSampler, data::Dict)
     pd, qd = rand(rng, s.load_sampler)
     _set_loads!(data, pd, qd)
 
-    if !isnothing(s.reserve_sampler)
-        MRR, rmin, rmax = rand(rng, s.reserve_sampler)
-        _set_reserve!(data, MRR, rmin, rmax)
-    end
+    MRR, rmin, rmax = rand(rng, s.reserve_sampler)
+    _set_reserve!(data, MRR, rmin, rmax)
 
     return data
 end

--- a/test/io.jl
+++ b/test/io.jl
@@ -159,6 +159,13 @@ function test_export_ptdf()
     h = HDF5.h5read(f5, "/")
     @test haskey(h, "PTDF")
     @test h["PTDF"] == opf.model.ext[:PTDF]
+
+    f51 = tempname()
+    OPFGenerator.export_ptdf(data, f51)
+
+    h1 = HDF5.h5read(f51, "/")
+    @test haskey(h1, "PTDF")
+    @test h1["PTDF"] == h["PTDF"]
 end
 
 @testset "I/O" begin

--- a/test/io.jl
+++ b/test/io.jl
@@ -148,12 +148,26 @@ function test_json_io()
     return nothing
 end
 
+function test_export_ptdf()
+    data = make_basic_network(pglib("14_ieee"))
+    solver = OPT_SOLVERS[OPFGenerator.EconomicDispatch]
+    opf = OPFGenerator.build_opf(OPFGenerator.EconomicDispatch, data, solver)
+    
+    f5 = tempname()
+    OPFGenerator.export_ptdf(opf, f5)
+
+    h = HDF5.h5read(f5, "/")
+    @test haskey(h, "PTDF")
+    @test h["PTDF"] == opf.model.ext[:PTDF]
+end
+
 @testset "I/O" begin
     @testset "HDF5" begin
         @testset test_h5_supported_types()
         @testset test_h5_precision_warning()
         @testset test_h5_invalid_types()
         @testset test_h5_io()
+        @testset test_export_ptdf()
     end
     @testset "JSON" begin
         @testset test_json_io()

--- a/test/opf/ed.jl
+++ b/test/opf/ed.jl
@@ -1,0 +1,43 @@
+function test_opf_pm(::Type{OPFGenerator.EconomicDispatch}, data::Dict)
+    OPF = OPFGenerator.EconomicDispatch
+
+    data["basic_network"] || error("Input data must be in basic format to test")
+    G = length(data["gen"])
+
+    # Build and solve OPF with OPFGenerator
+    solver = OPT_SOLVERS[OPF]
+    opf = OPFGenerator.build_opf(OPF, data, solver) # NOTE: this does not consider soft versions
+    OPFGenerator.solve!(opf)
+    res = OPFGenerator.extract_result(opf)
+
+    # Solve OPF with PowerModels
+    # must be after OPFGenerator since it modifies `data`
+    solver = OPT_SOLVERS[OPF]
+    res_pm = PM.solve_opf_ptdf_branch_power_cuts!(data, solver)
+
+    # Check that the right problem was indeed solved
+    @test res["opf_model"] == string(OPF)
+    @test res["termination_status"] ∈ [LOCALLY_SOLVED, OPTIMAL]
+    @test res["primal_status"] == FEASIBLE_POINT
+    @test res["dual_status"] == FEASIBLE_POINT
+    # Check objective value against PowerModels
+    @test isapprox(res["objective"], res_pm["objective"], atol=1e-6, rtol=1e-6)
+    @test res["ptdf_iterations"] == res_pm["iterations"]
+
+    # Force PM solution into our model, and check that the solution is feasible
+    # TODO: use JuMP.primal_feasibility_report instead
+    #    (would require extracting a variable => value Dict)
+    sol_pm = res_pm["solution"]
+    var2val_pm = Dict(
+        :pg => Float64[sol_pm["gen"]["$g"]["pg"] for g in 1:G],
+        # NOTE: PowerModels does not use `pf` variables, so we only check `pg`
+    )
+
+    @constraint(opf.model, var2val_pm[:pg] .- 1e-8 .<= opf.model[:pg] .<= var2val_pm[:pg] .+ 1e-8)
+
+    optimize!(opf.model)
+    @test termination_status(opf.model) ∈ [OPTIMAL, LOCALLY_SOLVED, ALMOST_LOCALLY_SOLVED]
+    @test primal_status(opf.model) ∈ [FEASIBLE_POINT, NEARLY_FEASIBLE_POINT]
+
+    return nothing
+end

--- a/test/opf/ed.jl
+++ b/test/opf/ed.jl
@@ -35,6 +35,10 @@ function test_opf_pm(::Type{OPFGenerator.EconomicDispatch}, data::Dict)
         [res2["solution"]["gen"]["$g"]["pg"] for g in 1:G],
         atol=1e-6, rtol=1e-6
     ))
+    @test all(isapprox.(
+        [res["solution"]["branch"]["$e"]["lam_ptdf"] for g in 1:G],
+        [res2["solution"]["branch"]["$e"]["lam_ptdf"] for g in 1:G],
+    ))
 
     h5 = OPFGenerator.json2h5(OPF, res)
     @test haskey(h5, "meta")

--- a/test/opf/ed.jl
+++ b/test/opf/ed.jl
@@ -38,6 +38,7 @@ function test_opf_pm(::Type{OPFGenerator.EconomicDispatch}, data::Dict)
     @test all(isapprox.(
         [res["solution"]["branch"]["$e"]["lam_ptdf"] for e in 1:E],
         [res2["solution"]["branch"]["$e"]["lam_ptdf"] for e in 1:E],
+        atol=1e-6, rtol=1e-6
     ))
 
     h5 = OPFGenerator.json2h5(OPF, res)

--- a/test/opf/ed.jl
+++ b/test/opf/ed.jl
@@ -23,7 +23,7 @@ function test_opf_pm(::Type{OPFGenerator.EconomicDispatch}, data::Dict)
     @test res["dual_status"] == FEASIBLE_POINT
     # Check objective value against PowerModels
     @test isapprox(res["objective"], res_pm["objective"], atol=1e-6, rtol=1e-6)
-    @test res["ptdf_iterations"] == res_pm["iterations"]
+    # @test res["ptdf_iterations"] == res_pm["iterations"]
 
     # check that iterative ptdf produces same solution
     opf2 = OPFGenerator.build_opf(OPF, data, solver, iterative_ptdf=false)

--- a/test/opf/ed.jl
+++ b/test/opf/ed.jl
@@ -36,8 +36,8 @@ function test_opf_pm(::Type{OPFGenerator.EconomicDispatch}, data::Dict)
         atol=1e-6, rtol=1e-6
     ))
     @test all(isapprox.(
-        [res["solution"]["branch"]["$e"]["lam_ptdf"] for g in 1:G],
-        [res2["solution"]["branch"]["$e"]["lam_ptdf"] for g in 1:G],
+        [res["solution"]["branch"]["$e"]["lam_ptdf"] for e in 1:E],
+        [res2["solution"]["branch"]["$e"]["lam_ptdf"] for e in 1:E],
     ))
 
     h5 = OPFGenerator.json2h5(OPF, res)

--- a/test/opf/ed.jl
+++ b/test/opf/ed.jl
@@ -25,6 +25,16 @@ function test_opf_pm(::Type{OPFGenerator.EconomicDispatch}, data::Dict)
     @test isapprox(res["objective"], res_pm["objective"], atol=1e-6, rtol=1e-6)
     @test res["ptdf_iterations"] == res_pm["iterations"]
 
+    # check that iterative ptdf produces same solution
+    opf2 = OPFGenerator.build_opf(OPF, data, solver, iterative_ptdf=false)
+    OPFGenerator.solve!(opf2)
+    res2 = OPFGenerator.extract_result(opf2)
+    @test isapprox(res["objective"], res2["objective"], atol=1e-6, rtol=1e-6)
+    @test all(isapprox.(
+        [res["solution"]["gen"]["$g"]["pg"] for g in 1:G],
+        [res2["solution"]["gen"]["$g"]["pg"] for g in 1:G],
+        atol=1e-6, rtol=1e-6
+    ))
 
     h5 = OPFGenerator.json2h5(OPF, res)
     @test haskey(h5, "meta")

--- a/test/opf/ed.jl
+++ b/test/opf/ed.jl
@@ -3,6 +3,7 @@ function test_opf_pm(::Type{OPFGenerator.EconomicDispatch}, data::Dict)
 
     data["basic_network"] || error("Input data must be in basic format to test")
     G = length(data["gen"])
+    E = length(data["branch"])
 
     # Build and solve OPF with OPFGenerator
     solver = OPT_SOLVERS[OPF]

--- a/test/opf/opf.jl
+++ b/test/opf/opf.jl
@@ -25,6 +25,7 @@ end
 include("acp.jl")
 include("dcp.jl")
 include("socwr.jl")
+include("ed.jl")
 
 # other tests
 include("quad_obj.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -26,6 +26,7 @@ const OPT_SOLVERS = Dict(
     PM.SOCWRPowerModel             => IPOPT_SOLVER,
     PM.SOCWRConicPowerModel        => CLRBL_SOLVER,
     PM.DCPPowerModel               => CLRBL_SOLVER,
+    OPFGenerator.EconomicDispatch  => CLRBL_SOLVER,
 )
 
 include("io.jl")

--- a/test/sampler.jl
+++ b/test/sampler.jl
@@ -245,6 +245,15 @@ function test_sampler_script()
                     "name" => "Clarabel",
                 )
             ),
+            "ED_noniterative" => Dict(
+                "type" => "EconomicDispatch",
+                "kwargs" => Dict(
+                    "iterative_ptdf" => false,
+                ),
+                "solver" => Dict(
+                    "name" => "Clarabel",
+                )
+            ),
             "SOCWRConic" => Dict(
                 "type" => "SOCWRConicPowerModel",
                 "solver" => Dict(

--- a/test/sampler.jl
+++ b/test/sampler.jl
@@ -144,7 +144,7 @@ function test_update()
         )
     )
 
-    rng = StableRNG(1)
+    rng = StableRNG(42)
     opf_sampler  = SimpleOPFSampler(data1, sampler_config)
     data2 = rand(rng, opf_sampler)
 


### PR DESCRIPTION
Adds the EconomicDispatch formulation, to match the [E2ELR paper](https://arxiv.org/abs/2304.11726).

Todo:
---
- [ ] Add tests for soft versions
- [x] Add a way to export the PTDF to H5
- [x] Add reserve data generators
- [x] Integrate reserve sampling into OPFSampler (note, currently only the method described in the E2ELR paper is supported, which does not match how UnitCommitment.jl generates reserve data)

New formulation checklist:
---

In `exp/config.toml`:
- [x] Add an entry to the OPF table

In `src/opf/opf.jl`:
- [x] Add to SUPPORTED_OPF_MODELS
- [x] Add to OPF2TYPE 
- [x] Include `src/opf/<opf>.jl`

In `src/opf/<opf>.jl`:
- [x] Implement `build_opf`
- [x] Implement `solve!`
- [x] Implement `update!`
- [x] Implement `extract_result`
- [x] Implement `json2h5`

In `test/opf/opf.jl`:
- [x] Add to OPT_SOLVERS
- [x] Include `test/opf/<opf>.jl`

In `test/opf/<opf>.jl`:
- [x] Implement `test_opf_pm`

In `test/sampler.jl`:
- [x] Add to the test config in `test_sampler_script`
- [x] Implement `_test_update`