### PR TITLE
Bump Clarabel compat --> v0.9

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -32,7 +32,7 @@ StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 
 [compat]
-Clarabel = "0.6, 0.7"
+Clarabel = "0.9"
 Graphs = "1.8"
 Ipopt = "1.6"
 JuMP = "1"


### PR DESCRIPTION
Not much changes in Clarabel v0.9 since v0.7, except they improved numerical stability in [v0.8](https://github.com/oxfordcontrol/Clarabel.jl/releases/tag/v0.8.0)