### PR TITLE
Export bound duals separately in EconomicDispatch

### DIFF
--- a/src/opf/ed.jl
+++ b/src/opf/ed.jl
@@ -396,7 +396,7 @@ function extract_result(opf::OPFModel{EconomicDispatch})
 
                 "mu_df_lb" => dual(LowerBoundRef(model[:δf][e])),
 
-                "lam_ptdf" => isdefined(model[:ptdf_flow], e) ? dual(model[:ptdf_flow][e]) : 0.0,
+                "lam_ptdf" => isassigned(model[:ptdf_flow], e) ? dual(model[:ptdf_flow][e]) : 0.0,
             )
         end
     end

--- a/src/opf/ed.jl
+++ b/src/opf/ed.jl
@@ -365,8 +365,11 @@ function extract_result(opf::OPFModel{EconomicDispatch})
             "rmin" => get(data["gen"]["$g"], "rmin", 0.0),
             "rmax" => get(data["gen"]["$g"], "rmax", 0.0),
 
-            "mu_pg" => dual(LowerBoundRef(model[:pg][g])) - dual(UpperBoundRef(model[:pg][g])),
-            "mu_r" => dual(LowerBoundRef(model[:r][g])) - dual(UpperBoundRef(model[:r][g])),
+            "mu_pg_lb" => dual(LowerBoundRef(model[:pg][g])),
+            "mu_pg_ub" => dual(UpperBoundRef(model[:pg][g])),
+
+            "mu_r_lb" => dual(LowerBoundRef(model[:r][g])),
+            "mu_r_ub" => dual(UpperBoundRef(model[:r][g])),
 
             "mu_total_generation" => dual(model[:total_generation][g]),
         )
@@ -387,8 +390,13 @@ function extract_result(opf::OPFModel{EconomicDispatch})
                 # "pf" => value(model[:pf][e]),
                 "pf" => model.ext[:ptdf_pf][e],
                 "df" => value(model[:δf][e]),
-                "mu_pf" => dual(model[:pf_lower_bound][e]) - dual(model[:pf_upper_bound][e]),
-                "mu_df" => dual(LowerBoundRef(model[:δf][e])) - (has_upper_bound(model[:δf][e]) ? dual(UpperBoundRef(model[:δf][e])) : 0.0),
+
+                "mu_pf_lb" => dual(model[:pf_lower_bound][e]),
+                "mu_pf_ub" => dual(model[:pf_upper_bound][e]),
+
+                "mu_df_lb" => dual(LowerBoundRef(model[:δf][e])),
+                "mu_df_ub" => (has_upper_bound(model[:δf][e]) ? dual(UpperBoundRef(model[:δf][e])) : 0.0),
+
                 "lam_ptdf" => isdefined(model[:ptdf_flow], e) ? dual(model[:ptdf_flow][e]) : 0.0,
             )
         end
@@ -399,9 +407,14 @@ function extract_result(opf::OPFModel{EconomicDispatch})
         "dpb_shortage" => value(model[:δpb_shortage]),
         "dr_shortage" => value(model[:δr_shortage]),
 
-        "mu_dpb_surplus" => dual(LowerBoundRef(model[:δpb_surplus])) - (has_upper_bound(model[:δpb_surplus]) ? dual(UpperBoundRef(model[:δpb_surplus])) : 0.0),
-        "mu_dpb_shortage" => dual(LowerBoundRef(model[:δpb_shortage])) - (has_upper_bound(model[:δpb_shortage]) ? dual(UpperBoundRef(model[:δpb_shortage])) : 0.0),
-        "mu_dr_shortage" => dual(LowerBoundRef(model[:δr_shortage])) - (has_upper_bound(model[:δr_shortage]) ? dual(UpperBoundRef(model[:δr_shortage])) : 0.0),
+        "mu_dpb_surplus_lb" => dual(LowerBoundRef(model[:δpb_surplus])),
+        "mu_dpb_surplus_ub" => (has_upper_bound(model[:δpb_surplus]) ? dual(UpperBoundRef(model[:δpb_surplus])) : 0.0),
+
+        "mu_dpb_shortage_lb" => dual(LowerBoundRef(model[:δpb_shortage])),
+        "mu_dpb_shortage_ub" => (has_upper_bound(model[:δpb_shortage]) ? dual(UpperBoundRef(model[:δpb_shortage])) : 0.0),
+
+        "mu_dr_shortage_lb" => dual(LowerBoundRef(model[:δr_shortage])),
+        "mu_dr_shortage_ub" => (has_upper_bound(model[:δr_shortage]) ? dual(UpperBoundRef(model[:δr_shortage])) : 0.0),
 
         "mu_power_balance" => dual(model[:power_balance]),
         "mu_reserve_requirement" => dual(model[:reserve_requirement]),

--- a/src/opf/ed.jl
+++ b/src/opf/ed.jl
@@ -395,7 +395,6 @@ function extract_result(opf::OPFModel{EconomicDispatch})
                 "mu_pf_ub" => dual(model[:pf_upper_bound][e]),
 
                 "mu_df_lb" => dual(LowerBoundRef(model[:δf][e])),
-                "mu_df_ub" => (has_upper_bound(model[:δf][e]) ? dual(UpperBoundRef(model[:δf][e])) : 0.0),
 
                 "lam_ptdf" => isdefined(model[:ptdf_flow], e) ? dual(model[:ptdf_flow][e]) : 0.0,
             )
@@ -408,13 +407,8 @@ function extract_result(opf::OPFModel{EconomicDispatch})
         "dr_shortage" => value(model[:δr_shortage]),
 
         "mu_dpb_surplus_lb" => dual(LowerBoundRef(model[:δpb_surplus])),
-        "mu_dpb_surplus_ub" => (has_upper_bound(model[:δpb_surplus]) ? dual(UpperBoundRef(model[:δpb_surplus])) : 0.0),
-
         "mu_dpb_shortage_lb" => dual(LowerBoundRef(model[:δpb_shortage])),
-        "mu_dpb_shortage_ub" => (has_upper_bound(model[:δpb_shortage]) ? dual(UpperBoundRef(model[:δpb_shortage])) : 0.0),
-
         "mu_dr_shortage_lb" => dual(LowerBoundRef(model[:δr_shortage])),
-        "mu_dr_shortage_ub" => (has_upper_bound(model[:δr_shortage]) ? dual(UpperBoundRef(model[:δr_shortage])) : 0.0),
 
         "mu_power_balance" => dual(model[:power_balance]),
         "mu_reserve_requirement" => dual(model[:reserve_requirement]),

--- a/src/opf/ed.jl
+++ b/src/opf/ed.jl
@@ -446,15 +446,18 @@ function json2h5(::Type{EconomicDispatch}, res)
     )
 
     res_h5["dual"] = dres_h5 = Dict{String,Any}(
-        "mu_pg" => zeros(Float64, G),
-        "mu_r" => zeros(Float64, G),
+        "mu_pg_lb" => zeros(Float64, G),
+        "mu_pg_ub" => zeros(Float64, G),
+        "mu_r_lb" => zeros(Float64, G),
+        "mu_r_ub" => zeros(Float64, G),
         "mu_total_generation" => zeros(Float64, G),
-        "mu_pf" => zeros(Float64, E),
-        "mu_df" => zeros(Float64, E),
+        "mu_pf_lb" => zeros(Float64, E),
+        "mu_pf_ub" => zeros(Float64, E),
+        "mu_df_lb" => zeros(Float64, E),
         "lam_ptdf" => zeros(Float64, E),
-        "mu_dpb_surplus" => 0,
-        "mu_dpb_shortage" => 0,
-        "mu_dr_shortage" => 0,
+        "mu_dpb_surplus_lb" => 0,
+        "mu_dpb_shortage_lb" => 0,
+        "mu_dr_shortage_lb" => 0,
         "mu_power_balance" => 0,
         "mu_reserve_requirement" => 0,
     )
@@ -467,8 +470,10 @@ function json2h5(::Type{EconomicDispatch}, res)
         pres_h5["rmin"][g] = gsol["rmin"]
         pres_h5["rmax"][g] = gsol["rmax"]
 
-        dres_h5["mu_pg"][g] = gsol["mu_pg"]
-        dres_h5["mu_r"][g] = gsol["mu_r"]
+        dres_h5["mu_pg_lb"][g] = gsol["mu_pg_lb"]
+        dres_h5["mu_pg_ub"][g] = gsol["mu_pg_ub"]
+        dres_h5["mu_r_lb"][g] = gsol["mu_r_lb"]
+        dres_h5["mu_r_ub"][g] = gsol["mu_r_ub"]
         dres_h5["mu_total_generation"][g] = gsol["mu_total_generation"]
     end
 
@@ -478,8 +483,11 @@ function json2h5(::Type{EconomicDispatch}, res)
         pres_h5["pf"][e] = brsol["pf"]
         pres_h5["df"][e] = brsol["df"]
 
-        dres_h5["mu_pf"][e] = brsol["mu_pf"]
-        dres_h5["mu_df"][e] = brsol["mu_df"]
+        dres_h5["mu_pf_lb"][e] = brsol["mu_pf_lb"]
+        dres_h5["mu_pf_ub"][e] = brsol["mu_pf_ub"]
+
+        dres_h5["mu_df_lb"][e] = brsol["mu_df_lb"]
+
         dres_h5["lam_ptdf"][e] = brsol["lam_ptdf"]
     end
 
@@ -488,9 +496,9 @@ function json2h5(::Type{EconomicDispatch}, res)
     pres_h5["dr_shortage"] = sol["singleton"]["dr_shortage"]
     pres_h5["minimum_reserve"] = res["minimum_reserve"]
 
-    dres_h5["mu_dpb_surplus"] = sol["singleton"]["mu_dpb_surplus"]
-    dres_h5["mu_dpb_shortage"] = sol["singleton"]["mu_dpb_shortage"]
-    dres_h5["mu_dr_shortage"] = sol["singleton"]["mu_dr_shortage"]
+    dres_h5["mu_dpb_surplus_lb"] = sol["singleton"]["mu_dpb_surplus_lb"]
+    dres_h5["mu_dpb_shortage_lb"] = sol["singleton"]["mu_dpb_shortage_lb"]
+    dres_h5["mu_dr_shortage_lb"] = sol["singleton"]["mu_dr_shortage_lb"]
     dres_h5["mu_power_balance"] = sol["singleton"]["mu_power_balance"]
     dres_h5["mu_reserve_requirement"] = sol["singleton"]["mu_reserve_requirement"]
 

--- a/test/opf/ed.jl
+++ b/test/opf/ed.jl
@@ -47,23 +47,25 @@ function test_opf_pm(::Type{OPFGenerator.EconomicDispatch}, data::Dict)
     @test haskey(h5, "dual")
     Gs = [
         h5["primal"]["pg"], h5["primal"]["r"],
-        h5["dual"]["mu_pg"], h5["dual"]["mu_r"],
+        h5["dual"]["mu_pg_lb"], h5["dual"]["mu_pg_ub"],
+        h5["dual"]["mu_r_lb"], h5["dual"]["mu_r_ub"],
         h5["dual"]["mu_total_generation"],
          # TODO: move reserve bounds to input
         h5["primal"]["rmin"], h5["primal"]["rmax"],
     ]
     Es = [
         h5["primal"]["pf"], h5["primal"]["df"],
-        h5["dual"]["mu_pf"], h5["dual"]["mu_df"],
+        h5["dual"]["mu_pf_lb"], h5["dual"]["mu_pf_ub"],
+        h5["dual"]["mu_df_lb"],
         h5["dual"]["lam_ptdf"],
     ]
     singles = [
         h5["primal"]["dpb_surplus"],
         h5["primal"]["dpb_shortage"],
         h5["primal"]["dr_shortage"],
-        h5["dual"]["mu_dpb_surplus"],
-        h5["dual"]["mu_dpb_shortage"],
-        h5["dual"]["mu_dr_shortage"],
+        h5["dual"]["mu_dpb_surplus_lb"],
+        h5["dual"]["mu_dpb_shortage_lb"],
+        h5["dual"]["mu_dr_shortage_lb"],
         h5["dual"]["mu_power_balance"],
         h5["dual"]["mu_reserve_requirement"],
     ]

--- a/test/opf/ed.jl
+++ b/test/opf/ed.jl
@@ -30,16 +30,6 @@ function test_opf_pm(::Type{OPFGenerator.EconomicDispatch}, data::Dict)
     OPFGenerator.solve!(opf2)
     res2 = OPFGenerator.extract_result(opf2)
     @test isapprox(res["objective"], res2["objective"], atol=1e-6, rtol=1e-6)
-    @test all(isapprox.(
-        [res["solution"]["gen"]["$g"]["pg"] for g in 1:G],
-        [res2["solution"]["gen"]["$g"]["pg"] for g in 1:G],
-        atol=1e-6, rtol=1e-6
-    ))
-    @test all(isapprox.(
-        [res["solution"]["branch"]["$e"]["lam_ptdf"] for e in 1:E],
-        [res2["solution"]["branch"]["$e"]["lam_ptdf"] for e in 1:E],
-        atol=1e-6, rtol=1e-6
-    ))
 
     h5 = OPFGenerator.json2h5(OPF, res)
     @test haskey(h5, "meta")


### PR DESCRIPTION
1. Export bound duals separately
1. Removes the non-existent slack upper bounds