### PR TITLE
ScaledUniform distribution

### DIFF
--- a/src/OPFGenerator.jl
+++ b/src/OPFGenerator.jl
@@ -13,7 +13,8 @@ using JuMP
 import Random: rand, rand!
 
 export load_json, save_json, save_h5
-export SimpleOPFSampler, LoadScaler, ScaledLogNormal
+export SimpleOPFSampler, LoadScaler
+export ScaledLogNormal, ScaledUniform
 
 include("utils/json.jl")
 include("utils/hdf5.jl")

--- a/src/sampler/glocal.jl
+++ b/src/sampler/glocal.jl
@@ -71,3 +71,27 @@ function ScaledLogNormal(l::Float64, u::Float64, σs::Vector{Float64})
 
     return Glocal(d_α, d_η)
 end
+
+"""
+    ScaledUniform
+
+A [`Glocal`](@ref) distribution `ϵ = α×η` where `α` is uniform and `ηᵢ` is uniform.
+"""
+const ScaledUniform = Glocal{Uniform{Float64},Product{Continuous,Uniform{Float64},Vector{Uniform{Float64}}}}
+
+"""
+    ScaledUniform(l, u, σs)
+
+Generate a `ScaledUniform` distribution where `α ~ U[l,u]` and `ηᵢ ~ U[1-σᵢ, 1+σᵢ]`.
+"""
+function ScaledUniform(l::Float64, u::Float64, σs::Vector{Float64})
+    l <= u || error("Invalid bounds: l > u")
+
+    # Uniform distribution
+    d_α = Uniform(l, u)
+    
+    # Load-level uniform distributions
+    d_η = Distributions.product_distribution([Uniform(1 - σ, 1 + σ) for σ in σs])
+
+    return Glocal(d_α, d_η)
+end

--- a/src/sampler/glocal.jl
+++ b/src/sampler/glocal.jl
@@ -61,6 +61,7 @@ Generate a `ScaledLogNormal` distribution where `α~U[l,u]` and `ηᵢ ~ LogNorm
 """
 function ScaledLogNormal(l::Float64, u::Float64, σs::Vector{Float64})
     l <= u || error("Invalid bounds: l > u")
+    all(σs .>= 0) || error("Invalid input: σs must be non-negative")
 
     # Uniform distribution
     d_α = Uniform(l, u)
@@ -86,6 +87,7 @@ Generate a `ScaledUniform` distribution where `α ~ U[l,u]` and `ηᵢ ~ U[1-σ�
 """
 function ScaledUniform(l::Float64, u::Float64, σs::Vector{Float64})
     l <= u || error("Invalid bounds: l > u")
+    all(σs .>= 0) || error("Invalid input: σs must be non-negative")
 
     # Uniform distribution
     d_α = Uniform(l, u)


### PR DESCRIPTION
This PR introduces a `ScaledUniform` distribution.
It is similar to the existing `ScaledLogNormal`, but uses uniform load-level noise instead of LogNormal, which allows to generate data with bounded support.

I also added some checks on the config input data.