### PR TITLE
Create dependabot.yml

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -1,0 +1,7 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This should ensure that our GH actions' versions are kept up-to-date.

See https://discourse.julialang.org/t/psa-use-dependabot-to-update-github-actions-automatically/96001 for context
