### PR TITLE
Add starter Manual and Reference sections to the docs

### DIFF
--- a/.github/workflows/doc_cleanup.yml
+++ b/.github/workflows/doc_cleanup.yml
@@ -1,0 +1,31 @@
+name: Doc Preview Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+# Ensure that only one "Doc Preview Cleanup" workflow is force pushing at a time
+concurrency:
+  group: doc-preview-cleanup
+  cancel-in-progress: false
+
+jobs:
+  doc-preview-cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+      - name: Delete preview and history + push changes
+        run: |
+          if [ -d "${preview_dir}" ]; then
+              git config user.name "Documenter.jl"
+              git config user.email "documenter@juliadocs.github.io"
+              git rm -rf "${preview_dir}"
+              git commit -m "delete preview"
+              git branch gh-pages-new $(echo "delete history" | git commit-tree HEAD^{tree})
+              git push --force origin gh-pages-new:gh-pages
+          fi
+        env:
+          preview_dir: previews/PR${{ github.event.number }}

--- a/README.md
+++ b/README.md
@@ -368,26 +368,6 @@ def parse_hdf5(path: str, preserve_shape: bool=False):
         return dat
 ```
 
-## Loading and saving JSON files
-
-Use the `load_json` and `save_json` functions to load/save data to/from JSON files.
-Uncompressed (`.json`) and compressed (`.json.gz` and `.json.bz2`) are supported automatically.
-
-```julia
-using OPFGenerator
-
-# Load a dictionary from a JSON file
-d = load_json("my_json_file.json")
-d = load_json("my_json_file.json.gz")
-d = load_json("my_json_file.json.bz2")
-
-# Save a dictionary to JSON file
-save_json("my_new_jsonfile.json", d)
-save_json("my_pretty_jsonfile.json", d, indent=2)  # prettier formatting
-save_json("my_new_jsonfile.json.gz", d)
-save_json("my_new_jsonfile.json.bz2", d)
-```
-
 ## Acknowledgements
 
 This material is based upon work supported by the National Science Foundation under Grant No. 2112533 NSF AI Institute for Advances in Optimization ([AI4OPT](https://www.ai4opt.org/)). 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,12 +2,17 @@ using Documenter
 using OPFGenerator
 
 makedocs(
+    modules=[OPFGenerator],
     sitename = "OPFGenerator",
     format = Documenter.HTML(;
         mathengine = Documenter.MathJax(),
     ),
     pages = [
         "Home" => "index.md",
+        "Manual" => [
+            "I/O utilities" => "io.md",
+        ],
+        "Reference" => "lib/public.md",
     ],
 )
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -19,4 +19,7 @@ makedocs(
 # Documenter can also automatically deploy documentation to gh-pages.
 # See "Hosting Documentation" and deploydocs() in the Documenter manual
 # for more information.
-deploydocs(repo="github.com/AI4OPT/OPFGenerator.git")
+deploydocs(
+    repo="github.com/AI4OPT/OPFGenerator.git",
+    push_preview=true,
+)

--- a/docs/src/io.md
+++ b/docs/src/io.md
@@ -1,0 +1,54 @@
+`OPFGenerator` provides utilities to save/load files in the HDF5 and JSON formats.
+
+## HDF5
+
+To load HDF5 files, use the [`load_h5`](@ref), which is the same as `HDF5.h5read`.
+```julia
+h = load_h5("test_file.h5", "/")  # load all HDF5 file
+```
+
+To save HDF5 files to disk, use the [`save_h5`](@ref) function.
+All keys of the dictionary (and sub-dictionaries) must be `String`s.
+
+```julia
+save_h5("myfile.h5", d)
+```
+
+!!! warning
+    
+    When exporting data to an HDF5 file, only the following data types are supported:
+    * `String`
+    * Number types [supported by HDF5.jl](https://juliaio.github.io/HDF5.jl/stable/#Supported-data-types)
+    * `Array`s of those
+
+    Numerical data in an unsupported type will be converted to `Float64`, when possible.
+
+## JSON
+
+!!! warning
+    Only `.json` extensions are supported
+
+Use the [`load_json`](@ref) and [`save_json`](@ref) functions to load/save data to/from JSON files.
+
+```julia
+using OPFGenerator
+
+# Load a dictionary from a JSON file
+d = load_json("my_json_file.json")
+
+# Save a dictionary to a JSON file
+save_json("my_new_jsonfile.json", d)
+save_json("my_pretty_jsonfile.json", d, indent=2)  # prettier formatting
+```
+
+Compressed JSON files (`.json.gz` and `.json.bz2`) are supported automatically
+
+```julia
+# Load a dictionary from a compressed JSON file
+d = load_json("my_json_file.json.gz")
+d = load_json("my_json_file.json.bz2")
+
+# Save a dictionary to a compressed JSON file
+save_json("my_new_jsonfile.json.gz", d)
+save_json("my_new_jsonfile.json.bz2", d)
+```

--- a/docs/src/lib/public.md
+++ b/docs/src/lib/public.md
@@ -1,0 +1,3 @@
+```@autodocs
+Modules = [OPFGenerator]
+```

--- a/src/OPFGenerator.jl
+++ b/src/OPFGenerator.jl
@@ -12,7 +12,7 @@ using JuMP
 
 import Random: rand, rand!
 
-export load_json, save_json, save_h5
+export load_json, save_json, load_h5, save_h5
 export SimpleOPFSampler, LoadScaler
 export ScaledLogNormal, ScaledUniform
 

--- a/src/utils/hdf5.jl
+++ b/src/utils/hdf5.jl
@@ -13,6 +13,30 @@ const HDF5_SUPPORTED_NUMBER_TYPES = Union{
     Complex{Float32}, Complex{Float64},
 }
 
+"""
+    load_h5
+"""
+load_h5 = HDF5.h5read
+
+"""
+    save_h5(filename, D)
+
+Saves dictionary `D` to HDF5 file `filename`.
+
+All keys in `D` must be of `String` type, and it must be HDF5-compatible.
+Additional restrictions are enforced on the values of `D`, see below.
+
+!!! warning
+    Only the following types are supported:
+    * `String`
+    * (un)signed integers up to 64-bit precision
+    * `Float32` and `Float64`
+    * `Complex` versions of the above numeric types
+    * Dense `Array`s of the the above scalar types
+
+    Numerical data of an unsupported type will be converted to `Float64` when possible.
+    An error will be thrown if the conversion is not possible.
+"""
 function save_h5(filename::AbstractString, D)
     h5open(filename, "w") do file
         _save_h5(file, D)

--- a/src/utils/json.jl
+++ b/src/utils/json.jl
@@ -4,6 +4,7 @@ using JSON
 
 """
     load_json(filename::AbstractString)
+    
 Load JSON data from file `filename`.
 """
 function load_json(filename::AbstractString)::Dict{String,Any}


### PR DESCRIPTION
To check this locally:

```bash
julia --project=docs -e 'using Pkg; Pkg.develop(path="."); Pkg.instantiate(); include("docs/make.jl");'
```

Then render the `docs/build/index.html` to browse the documentation locally.