### PR TITLE
Fix outages and use constant-sized arrays

### DIFF
--- a/exp/slow_sampler.jl
+++ b/exp/slow_sampler.jl
@@ -35,87 +35,71 @@ value_type(::Any) = Float64
 value_type(::Type{Clarabel.Optimizer{T}}) where{T} = T
 value_type(m::MOI.OptimizerWithAttributes) = value_type(m.optimizer_constructor)
 
-function build_models(data, config)
-    opf_models = Dict{String, Tuple{OPFGenerator.OPFModel{<:PowerModels.AbstractPowerModel}, Float64}}()
-    for (dataset_name, opf_config) in config["OPF"]
-        OPF = OPFGenerator.OPF2TYPE[opf_config["type"]]
-        solver_config = get(opf_config, "solver", Dict())
+function build_and_solve_model(data, config, dataset_name)
+    opf_config = config["OPF"][dataset_name]
+    OPF = OPFGenerator.OPF2TYPE[opf_config["type"]]
+    solver_config = get(opf_config, "solver", Dict())
 
-        if solver_config["name"] == "Ipopt"
-            # Make sure we provide an HSL path
-            # The code below does not modify anything if the user provides an HSL path
-            get!(solver_config, "attributes", Dict())
-            get!(solver_config["attributes"], "hsllib", HSL_jll.libhsl_path)
-        end
-
-        solver = optimizer_with_attributes(NAME2OPTIMIZER[solver_config["name"]],
-            get(solver_config, "attributes", Dict())...
-        )
-        build_kwargs = Dict(Symbol(k) => v for (k, v) in get(opf_config, "kwargs", Dict()))
-
-        tbuild = @elapsed opf = OPFGenerator.build_opf(OPF, data, solver;
-            T=value_type(solver.optimizer_constructor),
-            build_kwargs...
-        )
-
-        set_silent(opf.model)
-        opf_models[dataset_name] = (opf, tbuild)
-        @info "Built $dataset_name in $tbuild seconds"
+    if solver_config["name"] == "Ipopt"
+        # Make sure we provide an HSL path
+        get!(solver_config, "attributes", Dict())
+        get!(solver_config["attributes"], "hsllib", HSL_jll.libhsl_path)
     end
 
-    return opf_models
+    solver = optimizer_with_attributes(NAME2OPTIMIZER[solver_config["name"]],
+        get(solver_config, "attributes", Dict())...
+    )
+    build_kwargs = Dict(Symbol(k) => v for (k, v) in get(opf_config, "kwargs", Dict()))
+
+    tbuild = @elapsed opf = OPFGenerator.build_opf(OPF, data, solver;
+        T=value_type(solver.optimizer_constructor),
+        build_kwargs...
+    )
+
+    set_silent(opf.model)
+    
+    OPFGenerator.solve!(opf)
+
+    time_extract = @elapsed res = OPFGenerator.extract_result(opf)
+    
+    res["time_build"] = tbuild
+    res["time_extract"] = time_extract
+    
+    return OPFGenerator.json2h5(opf.model.ext[:opf_model], res)
 end
 
-function main(data, opf_models, config)
+function main(data, config)
     d = Dict{String,Any}()
     d["meta"] = deepcopy(config)
     
     # Keep track of input data
     d["data"] = data
 
-    for dataset_name in keys(opf_models)
-        opf = opf_models[dataset_name][1]
-
-        OPFGenerator.update!(opf, data)
-        OPFGenerator.solve!(opf)
-
-        time_extract = @elapsed res = OPFGenerator.extract_result(opf)
-        
-        res["time_build"] = opf_models[dataset_name][2]
-        res["time_extract"] = time_extract
-        h = OPFGenerator.json2h5(opf.model.ext[:opf_model], res)
-        d[dataset_name] = h
+    for dataset_name in keys(config["OPF"])
+        d[dataset_name] = build_and_solve_model(data, config, dataset_name)
     end
 
     return d
 end
 
-if abspath(PROGRAM_FILE) == @__FILE__
-    # Load config file
-    config = TOML.parsefile(ARGS[1])
-    # Parse seed range from CL arguments
-    smin = parse(Int, ARGS[2])
-    smax = parse(Int, ARGS[3])
+if true #abspath(PROGRAM_FILE) == @__FILE__
 
-    if get(get(get(config, "sampler", Dict()), "status", Dict()), "type", "Full") != "Full"
-        error("Status sampling must be `Full` for this sampler script, since it relies on update!. \
-              Use slow_sampler.jl for Nminus1 data generation.")
-    end
+    aARGS = ["exp/config.toml" "1" "5"]
+    # Load config file
+    config = TOML.parsefile(aARGS[1])
+    # Parse seed range from CL arguments
+    smin = parse(Int, aARGS[2])
+    smax = parse(Int, aARGS[3])
 
     # Dummy run (for pre-compilation)
     data0 = make_basic_network(pglib("14_ieee"))
     opf_sampler0 = OPFGenerator.SimpleOPFSampler(data0, config["sampler"])
     rand!(StableRNG(1), opf_sampler0, data0)
-    for (opf0, m0) in build_models(data0, config)
-        OPFGenerator.solve!(m0[1])
-        OPFGenerator.extract_result(m0[1])
-    end
+    main(data0, config)
 
     # Load reference data and setup OPF sampler
     data = make_basic_network(pglib(config["ref"]))
     opf_sampler = OPFGenerator.SimpleOPFSampler(data, config["sampler"])
-
-    opf_models = build_models(data, config)
 
     # Data info
     N = length(data["bus"])
@@ -151,7 +135,7 @@ if abspath(PROGRAM_FILE) == @__FILE__
     for s in smin:smax
         rng = StableRNG(s)
         tgen = @elapsed data_ = rand(rng, opf_sampler)
-        tsolve = @elapsed res = main(data_, opf_models, config)
+        tsolve = @elapsed res = main(data_, config)
         res["meta"]["seed"] = s
 
         # Update input data

--- a/slurm/submit_jobs.jl
+++ b/slurm/submit_jobs.jl
@@ -7,6 +7,8 @@ using TOML
 config_file = ARGS[1]
 config = TOML.parsefile(config_file)
 
+opfgenerator_dir = "$(@__DIR__)/../"
+
 case = config["ref"]
 result_dir = config["export_dir"]
 S = config["slurm"]["n_samples"]
@@ -22,14 +24,12 @@ sysimage_memory = get(config["slurm"], "sysimage_memory", "16gb")
 julia_bin = get(config["slurm"], "julia_bin", "julia --sysimage=app/julia.so")
 cpus_per_task = get(config["slurm"], "cpus_per_task", 24)
 env_path = get(config["slurm"], "env_path", joinpath(@__DIR__, "template", "env.sh"))
+sampler_script = get(config["slurm"], "sampler_script", joinpath(opfgenerator_dir, "exp", "sampler.jl"))
 
 B, r = divrem(S, J)
 B = B + (r > 0)
 
 datasetname = splitdir(result_dir)[end]
-
-opfgenerator_dir = "$(@__DIR__)/../"
-sampler_script = joinpath(opfgenerator_dir, "exp", "sampler.jl")
 
 slurm_dir = joinpath(result_dir, "slurm")
 json_dir = joinpath(result_dir, "res_json")

--- a/src/opf/opf.jl
+++ b/src/opf/opf.jl
@@ -5,6 +5,7 @@ mutable struct OPFModel{OPF <: PM.AbstractPowerModel}
     model::JuMP.GenericModel
 end
 
+include("utils.jl")
 include("acp.jl")      # ACPPowerModel
 include("dcp.jl")      # DCPPowerModel
 include("ed.jl")       # EconomicDispatch

--- a/src/opf/utils.jl
+++ b/src/opf/utils.jl
@@ -1,0 +1,170 @@
+## arcs
+
+ArcType = Tuple{Int, Int, Int}
+
+function make_arcs_from(data::Dict{String,Any})
+    return [
+        (l, data["branch"]["$l"]["f_bus"], data["branch"]["$l"]["t_bus"])
+        for l in 1:length(data["branch"])
+    ]
+end
+
+function make_arcs_to(data::Dict{String,Any})
+    return [
+        (l, data["branch"]["$l"]["t_bus"], data["branch"]["$l"]["f_bus"])
+        for l in 1:length(data["branch"])
+    ]
+end
+
+function make_arcs_to(arcs_from::Vector{ArcType})
+    return [(l, j, i) for (l, i, j) in arcs_from]
+end
+
+function make_arcs(data::Dict{String,Any})
+    arcs_from = make_arcs_from(data)
+    return make_arcs(arcs_from)
+end
+
+function make_arcs(arcs_from::Vector{ArcType})
+    return [arcs_from; make_arcs_to(arcs_from)]
+end
+
+## bus_*
+
+function make_bus_loads(data::Dict{String,Any})
+    bus_loads = Vector{Vector{Int}}(undef, length(data["bus"]))
+    L = length(data["load"])
+    for b in 1:length(data["bus"])
+        bus_loads[b] = [
+            l for l in 1:L if data["load"]["$l"]["load_bus"] == b
+        ]
+    end
+    return bus_loads
+end
+
+function make_bus_shunts(data::Dict{String,Any}) # TODO: vector of vectors
+    bus_shunts = Vector{Vector{Int}}(undef, length(data["bus"]))
+    S = length(data["shunt"])
+    for b in 1:length(data["bus"])
+        bus_shunts[b] = [
+            s for s in 1:S if data["shunt"]["$s"]["shunt_bus"] == b
+        ]
+    end
+    return bus_shunts
+end
+
+function make_bus_gens(data::Dict{String,Any})
+    bus_gens = Vector{Vector{Int}}(undef, length(data["bus"]))
+    G = length(data["gen"])
+    for b in 1:length(data["bus"])
+        bus_gens[b] = [
+            g for g in 1:G if data["gen"]["$g"]["gen_bus"] == b
+        ]
+    end
+    return bus_gens
+end
+
+function make_bus_arcs(data::Dict{String,Any})
+    arcs_from = make_arcs_from(data)
+    return make_bus_arcs(data, arcs_from)
+end
+
+function make_bus_arcs(data::Dict{String,Any}, arcs_from::Vector{ArcType})
+    bus_arcs = Vector{Vector{ArcType}}(undef, length(data["bus"]))
+    for b in 1:length(data["bus"])
+        bus_arcs[b] = [
+            # if from bus, add arc as is
+            # if to bus, swap from and to
+            i == b ? (l, i, j) : (l, j, i)
+            for (l, i, j) in arcs_from
+            if (i == b || j == b)
+        ]
+    end
+    return bus_arcs
+end
+
+function make_ref_buses(data::Dict{String,Any})
+    return [
+        b for b in 1:length(data["bus"])
+        if data["bus"]["$b"]["bus_type"] == 3
+    ]
+end
+
+## active_*
+
+function make_active_branches(data::Dict{String,Any})
+    return [
+        l for l in 1:length(data["branch"])
+        if data["branch"]["$l"]["br_status"] == 1
+    ]
+end
+
+function make_active_generators(data::Dict{String,Any})
+    return [
+        g for g in 1:length(data["gen"])
+        if data["gen"]["$g"]["gen_status"] == 1
+    ]
+end
+
+""" 
+    fix_variables(status, vars)
+
+Fix variables by setting their lower and upper bounds to zero if the corresponding status is zero.
+Note this differs from JuMP.fix which creates an equality constraint and removes bounds.
+"""
+function zero_variables(status::Vector{Int}, vars)
+    @assert length(status) == length(vars) "status and vars must have the same length"
+    for (s, v) in zip(status, vars)
+        if s == 0
+            JuMP.set_lower_bound(v, 0.0)
+            JuMP.set_upper_bound(v, 0.0)
+        end
+    end
+end
+
+
+function calc_buspair_voltage_bounds!(data::Dict{String,Any})
+    E = length(data["branch"])
+    
+    data["buspair"] = buspairs = Dict{Tuple{Int,Int},Dict{String,Float64}}()
+    for e in 1:E
+        i = data["branch"]["$e"]["f_bus"]
+        j = data["branch"]["$e"]["t_bus"]
+
+        if !haskey(buspairs, (i,j))
+            buspairs[(i,j)] = Dict{String,Float64}()
+            buspairs[(i,j)]["angmin"] = data["branch"]["$e"]["angmin"]
+            buspairs[(i,j)]["angmax"] = data["branch"]["$e"]["angmax"]
+        else
+            buspairs[(i,j)]["angmin"] = max(buspairs[(i,j)]["angmin"], data["branch"]["$e"]["angmin"])
+            buspairs[(i,j)]["angmax"] = min(buspairs[(i,j)]["angmax"], data["branch"]["$e"]["angmax"])
+        end
+
+    end
+
+    for (i,j) in keys(buspairs)
+        buspair = buspairs[(i,j)]
+
+        busi = data["bus"]["$i"]
+        busj = data["bus"]["$j"]
+
+        if buspair["angmin"] >= 0
+            buspairs[(i,j)]["wr_min"] = busi["vmin"]*busj["vmin"]*cos(buspair["angmax"])
+            buspairs[(i,j)]["wr_max"] = busi["vmax"]*busj["vmax"]*cos(buspair["angmin"])
+            buspairs[(i,j)]["wi_min"] = busi["vmin"]*busj["vmin"]*sin(buspair["angmin"])
+            buspairs[(i,j)]["wi_max"] = busi["vmax"]*busj["vmax"]*sin(buspair["angmax"])
+        end
+        if buspair["angmax"] <= 0
+            buspairs[(i,j)]["wr_min"] = busi["vmin"]*busj["vmin"]*cos(buspair["angmin"])
+            buspairs[(i,j)]["wr_max"] = busi["vmax"]*busj["vmax"]*cos(buspair["angmax"])
+            buspairs[(i,j)]["wi_min"] = busi["vmax"]*busj["vmax"]*sin(buspair["angmin"])
+            buspairs[(i,j)]["wi_max"] = busi["vmin"]*busj["vmin"]*sin(buspair["angmax"])
+        end
+        if buspair["angmin"] < 0 && buspair["angmax"] > 0
+            buspairs[(i,j)]["wr_min"] = busi["vmin"]*busj["vmin"]*min(cos(buspair["angmin"]), cos(buspair["angmax"]))
+            buspairs[(i,j)]["wr_max"] = busi["vmax"]*busj["vmax"]*1.0
+            buspairs[(i,j)]["wi_min"] = busi["vmax"]*busj["vmax"]*sin(buspair["angmin"])
+            buspairs[(i,j)]["wi_max"] = busi["vmax"]*busj["vmax"]*sin(buspair["angmax"])
+        end
+    end
+end

--- a/src/sampler/status.jl
+++ b/src/sampler/status.jl
@@ -1,0 +1,81 @@
+import Distributions: length, eltype, _rand!
+
+abstract type AbstractStatusSampler end
+
+"""
+    Nminus1StatusSampler
+
+Samples a branch or generator to be inactive following the procedure below:
+
+1. With probability 1/2, decide if a branch or generator is inactive in this instance.
+
+If a branch is inactive:
+2. Identify the set of branches which are not bridges. Removing a bridge results in a disconnected network.
+3. Sample a branch to be inactive from the set of non-bridge branches.
+4. Construct the status vector to be all ones except for zero at the sampled branch.
+
+If a generator is inactive:
+2. Sample a generator to be inactive.
+3. Construct the status vector to be all ones except for zero at the sampled generator.
+"""
+struct Nminus1StatusSampler <: AbstractStatusSampler
+    data::Dict
+end
+
+function Random.rand(rng::AbstractRNG, rs::Nminus1StatusSampler)
+    p = rand(rng)
+
+    if p < 0.5
+        # drop a branch 
+        is_bridge = bridges(rs.data)
+        non_bridge = [e for (e, b) in is_bridge if !b]
+        
+        e = rand(rng, non_bridge)
+        e_index = rs.data["branch"][e]["index"]
+
+        br_status = ones(Int, length(rs.data["branch"]))
+        br_status[e_index] = 0
+
+        gen_status = ones(Int, length(rs.data["gen"]))
+
+        return br_status, gen_status
+
+    else
+        # drop a generator
+        G = length(rs.data["gen"])
+        g = rand(rng, 1:G)
+
+        gen_status = ones(Int, G)
+        gen_status[g] = 0
+
+        br_status = ones(Int, length(rs.data["branch"]))
+
+        return br_status, gen_status
+
+    end
+end
+
+
+struct FullStatusSampler <: AbstractStatusSampler
+    data::Dict
+end
+
+function Random.rand(rng::AbstractRNG, rs::FullStatusSampler)
+    return ones(Int, length(rs.data["branch"])), ones(Int, length(rs.data["gen"]))
+end
+
+function StatusSampler(data::Dict, options::Dict)
+    get(data, "basic_network", false) || error(
+        """Invalid data: network data must be in basic format.
+        Call `make_basic_network(data)` before calling this function"""
+    )
+
+    status_type = get(options, "type", "Full")
+    if status_type == "Nminus1"
+        return Nminus1StatusSampler(data)
+    elseif status_type == "Full"
+        return FullStatusSampler(data)
+    else
+        error("Invalid status sampler type: $status_type. Only 'Nminus1' and 'Full' are supported.")
+    end
+end

--- a/test/opf/acp.jl
+++ b/test/opf/acp.jl
@@ -29,8 +29,12 @@ function test_opf_pm(::Type{PM.ACPPowerModel}, data::Dict)
     #    (would require extracting a variable => value Dict)
     sol_pm = res_pm["solution"]
     var2val_pm = Dict(
-        :pg => Float64[sol_pm["gen"]["$g"]["pg"] for g in 1:G],
-        :qg => Float64[sol_pm["gen"]["$g"]["qg"] for g in 1:G],
+        :pg => Float64[
+            get(get(sol_pm["gen"], "$g", Dict()), "pg", 0) for g in 1:G
+        ],
+        :qg => Float64[
+            get(get(sol_pm["gen"], "$g", Dict()), "qg", 0) for g in 1:G
+        ],
         :va => Float64[sol_pm["bus"]["$i"]["va"] for i in 1:N],
         :vm => Float64[sol_pm["bus"]["$i"]["vm"] for i in 1:N],
     )

--- a/test/opf/dcp.jl
+++ b/test/opf/dcp.jl
@@ -30,9 +30,13 @@ function test_opf_pm(::Type{PM.DCPPowerModel}, data::Dict)
     #    (would require extracting a variable => value Dict)
     sol_pm = res_pm["solution"]
     var2val_pm = Dict(
-        :pg => Float64[sol_pm["gen"]["$g"]["pg"] for g in 1:G],
+        :pg => Float64[
+            get(get(sol_pm["gen"], "$g", Dict()), "pg", 0) for g in 1:G
+        ],
         :va => Float64[sol_pm["bus"]["$i"]["va"] for i in 1:N],
-        :pf => Float64[sol_pm["branch"]["$e"]["pf"] for e in 1:E],
+        :pf => Float64[
+            get(get(sol_pm["branch"], "$e", Dict()), "pf", 0) for e in 1:E
+        ],
     )
     model = opf.model
     # reorder pf according to branch order in our model

--- a/test/opf/ed.jl
+++ b/test/opf/ed.jl
@@ -68,7 +68,9 @@ function test_opf_pm(::Type{OPFGenerator.EconomicDispatch}, data::Dict)
     #    (would require extracting a variable => value Dict)
     sol_pm = res_pm["solution"]
     var2val_pm = Dict(
-        :pg => Float64[sol_pm["gen"]["$g"]["pg"] for g in 1:G],
+        :pg => Float64[
+            get(get(sol_pm["gen"], "$g", Dict()), "pg", 0) for g in 1:G
+        ],
         # NOTE: PowerModels does not use `pf` variables, so we only check `pg`
     )
 

--- a/test/opf/utils.jl
+++ b/test/opf/utils.jl
@@ -63,8 +63,8 @@ function test_active_branches(data, ref)
 
     data_ = deepcopy(data)
     data_["branch"]["1"]["br_status"] = 0
-    n1_active_branches = OPFGenerator.make_active_branches(data)
-    n1_ref = PM.build_ref(data)[:it][:pm][:nw][0]
+    n1_active_branches = OPFGenerator.make_active_branches(data_)
+    n1_ref = PM.build_ref(data_)[:it][:pm][:nw][0]
     @test n1_active_branches == sort(collect(keys(n1_ref[:branch])))
 end
 
@@ -74,8 +74,8 @@ function test_active_generators(data, ref)
 
     data_ = deepcopy(data)
     data_["gen"]["1"]["gen_status"] = 0
-    n1_active_generators = OPFGenerator.make_active_generators(data)
-    n1_ref = PM.build_ref(data)[:it][:pm][:nw][0]
+    n1_active_generators = OPFGenerator.make_active_generators(data_)
+    n1_ref = PM.build_ref(data_)[:it][:pm][:nw][0]
     @test n1_active_generators == sort(collect(keys(n1_ref[:gen])))
 end
 

--- a/test/opf/utils.jl
+++ b/test/opf/utils.jl
@@ -1,0 +1,123 @@
+function test_arcs_from(data, ref)
+    arcs_from = OPFGenerator.make_arcs_from(data)
+    @test arcs_from == sort(ref[:arcs_from], by=x->x[1])
+end
+
+function test_arcs_to(data, ref)
+    arcs_to = OPFGenerator.make_arcs_to(data)
+    @test arcs_to == sort(ref[:arcs_to], by=x->x[1])
+end
+
+function test_arcs(data, ref)
+    arcs = OPFGenerator.make_arcs(data)
+    @test length(arcs) == length(ref[:arcs])
+    # `arcs` is ordered like [arcs_from; arcs_to]
+    # ideally sort ref[:arcs] to match but sorting both suffices
+    @test sort(arcs, by=x->x[1]) == sort(ref[:arcs], by=x->(x[1]))
+end
+
+function test_bus_loads(data, ref)
+    bus_loads = OPFGenerator.make_bus_loads(data)
+    rbus_loads = ref[:bus_loads]
+    for (k, v) in rbus_loads
+        rbus_loads[k] = sort(v)
+    end
+    @test bus_loads == [rbus_loads[b] for b in 1:length(data["bus"])]
+end
+
+function test_bus_shunts(data, ref)
+    bus_shunts = OPFGenerator.make_bus_shunts(data)
+    rbus_shunts = ref[:bus_shunts]
+    for (k, v) in rbus_shunts
+        rbus_shunts[k] = sort(v)
+    end
+    @test bus_shunts == [rbus_shunts[b] for b in 1:length(data["bus"])]
+end
+
+function test_bus_gens(data, ref)
+    bus_gens = OPFGenerator.make_bus_gens(data)
+    rbus_gens = ref[:bus_gens]
+    for (k, v) in rbus_gens
+        rbus_gens[k] = sort(v)
+    end
+    @test bus_gens == [rbus_gens[b] for b in 1:length(data["bus"])]
+end
+
+function test_bus_arcs(data, ref)
+    bus_arcs = OPFGenerator.make_bus_arcs(data)
+    rbus_arcs = ref[:bus_arcs]
+    for (k, v) in rbus_arcs
+        rbus_arcs[k] = sort(v, by=x->x[1])
+    end
+    @test bus_arcs == [rbus_arcs[b] for b in 1:length(data["bus"])]
+end
+
+function test_ref_buses(data, ref)
+    ref_buses = OPFGenerator.make_ref_buses(data)
+    @test ref_buses == sort(collect(keys(ref[:ref_buses])))
+end
+
+function test_active_branches(data, ref)
+    active_branches = OPFGenerator.make_active_branches(data)
+    @test active_branches == sort(collect(keys(ref[:branch])))
+
+    data_ = deepcopy(data)
+    data_["branch"]["1"]["br_status"] = 0
+    n1_active_branches = OPFGenerator.make_active_branches(data)
+    n1_ref = PM.build_ref(data)[:it][:pm][:nw][0]
+    @test n1_active_branches == sort(collect(keys(n1_ref[:branch])))
+end
+
+function test_active_generators(data, ref)
+    active_generators = OPFGenerator.make_active_generators(data)
+    @test active_generators == sort(collect(keys(ref[:gen])))
+
+    data_ = deepcopy(data)
+    data_["gen"]["1"]["gen_status"] = 0
+    n1_active_generators = OPFGenerator.make_active_generators(data)
+    n1_ref = PM.build_ref(data)[:it][:pm][:nw][0]
+    @test n1_active_generators == sort(collect(keys(n1_ref[:gen])))
+end
+
+# function test_fix_variables(data, ref)
+#     # TODO
+# end
+
+function test_calc_buspair_voltage_bounds(data, ref)
+    data_ = deepcopy(data)
+    calc_buspair_voltage_bounds!(data_)
+
+    wr_min = Dict((i,j) => data_["buspair"][(i,j)]["wr_min"] for (i,j) in keys(data_["buspair"]))
+    wr_max = Dict((i,j) => data_["buspair"][(i,j)]["wr_max"] for (i,j) in keys(data_["buspair"]))
+    wi_min = Dict((i,j) => data_["buspair"][(i,j)]["wi_min"] for (i,j) in keys(data_["buspair"]))
+    wi_max = Dict((i,j) => data_["buspair"][(i,j)]["wi_max"] for (i,j) in keys(data_["buspair"]))
+
+    buspairs = PowerModels.calc_buspair_parameters(data["bus"], data["branch"])
+    wr_min_pm, wr_max_pm, wi_min_pm, wi_max_pm = PowerModels.calc_buspair_voltage_bounds(buspairs)
+
+    @test wr_min == wr_min_pm
+    @test wr_max == wr_max_pm
+    @test wi_min == wi_min_pm
+    @test wi_max == wi_max_pm
+end
+
+function test_utils(casename)
+    data = PM.make_basic_network(pglib(casename))
+    rref = PM.build_ref(data)[:it][:pm][:nw][0]
+    @testset test_arcs_from(data, rref)
+    @testset test_arcs_to(data, rref)
+    @testset test_arcs(data, rref)
+    @testset test_bus_loads(data, rref)
+    @testset test_bus_shunts(data, rref)
+    @testset test_bus_gens(data, rref)
+    @testset test_bus_arcs(data, rref)
+    @testset test_ref_buses(data, rref)
+    @testset test_active_branches(data, rref)
+    @testset test_active_generators(data, rref)
+end
+
+@testset "Utils" begin
+    @testset "$(casename)" for casename in PGLIB_CASES
+        test_utils(casename)
+    end
+end


### PR DESCRIPTION
This PR:
- Introduces status sampling for generator/branch outages. `Nminus1` is implemented to select either one branch or one generator to disable, following [OPFData](https://arxiv.org/abs/2406.07234). A new sampler script `slow_sampler.jl` is added since `update!` only works for RHS changes.
- Reformulates using constant-size arrays, removing the dependency on `PM.build_ref` which itself filters out disabled components. Fixes #107.