### PR TITLE
Replace types

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ Primal variables
 |           | `"wr"` | Real part of voltage product
 |           | `"wi"` | Imaginary part of voltage product
 
-Dual variables depend on whether a quadratic (`SOCWRPowerModel`) or conic (`SOCWRConicPowerModel`) formulation is considered.
+Dual variables depend on whether a quadratic (`SOCOPFQuad`) or conic (`SOCOPF`) formulation is considered.
 The former are identified with `(quad)`, the latter with `(cone)` in the table below.
 Only the dual variables of quadratic constraints are affected by this distinction.
 Note that conic dual are high-dimensional variables, and separate coordinates are stored separately.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Instance generator for various OPF problems (ACOPF & DCOPF currently supported)
     - [Building and solving OPF problems](#building-and-solving-opf-problems)
   - [Generating datasets](#generating-datasets)
   - [Solution format](#solution-format)
-    - [ACPPowerModel](#acppowermodel)
+    - [ACOPF](#ACOPF)
     - [DCPPowerModel](#dcppowermodel)
     - [SOCWRPowerModel](#socwrpowermodel)
   - [Datasets](#datasets)
@@ -127,7 +127,7 @@ using Ipopt
 using OPFGenerator
 
 data = make_basic_network(pglib("14_ieee"))
-acopf = OPFGenerator.build_opf(PowerModels.ACPPowerModel, data, Ipopt.Optimizer)
+acopf = OPFGenerator.build_opf(ACOPF, data, Ipopt.Optimizer)
 optimize!(acopf.model)
 res = OPFGenerator.extract_result(acopf)
 
@@ -155,7 +155,7 @@ As a convention, dual variables of equality constraints are named `lam_<constrai
 
 Collections of instances & solutions are stored in a compact, array-based HDF5 file (see [Datasets/Format](#format) below.)
 
-### ACPPowerModel
+### ACOPF
 
 See [PowerModels documentation](https://lanl-ansi.github.io/PowerModels.jl/stable/formulation-details/#PowerModels.ACPPowerModel).
 
@@ -286,7 +286,7 @@ See [Solution format](#solution-format) for a list of each formulation's primal 
 |   |-- pd
 |   |-- qd
 |   |-- br_status
-|-- ACPPowerModel
+|-- ACOPF
 |   |-- meta
 |   |   |-- termination_status
 |   |   |-- primal_status

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Instance generator for various OPF problems (ACOPF & DCOPF currently supported)
   - [Generating datasets](#generating-datasets)
   - [Solution format](#solution-format)
     - [ACOPF](#ACOPF)
-    - [DCPPowerModel](#dcppowermodel)
+    - [DCOPF](#DCOPF)
     - [SOCWRPowerModel](#socwrpowermodel)
   - [Datasets](#datasets)
     - [Format](#format)
@@ -192,7 +192,7 @@ Dual variables
 |           | `"lam_ohm_reactive_to"`    | Ohm's law; reactive power (to)
 |           | `"mu_va_diff"`             | Voltage angle difference
 
-### DCPPowerModel
+### DCOPF
 
 See [PowerModels documentation](https://lanl-ansi.github.io/PowerModels.jl/stable/formulation-details/#PowerModels.DCPPowerModel).
 
@@ -300,7 +300,7 @@ See [Solution format](#solution-format) for a list of each formulation's primal 
 |       |-- lam_kirchhoff_active
 |       |-- lam_kirchhoff_reactive
 |       |-- ...
-|-- DCPPowerModel
+|-- DCOPF
 |   |-- meta
 |   |-- primal
 |   |-- dual

--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ See [Solution format](#solution-format) for a list of each formulation's primal 
 |   |-- meta
 |   |-- primal
 |   |-- dual
-|-- SOCWRConicPowerModel
+|-- SOCOPF
     |-- meta
     |-- primal
     |-- dual

--- a/exp/config.toml
+++ b/exp/config.toml
@@ -27,7 +27,7 @@ type = "DCPPowerModel"
 solver.name = "Mosek"
 
 [OPF.ACOPF]
-type = "ACPPowerModel"
+type = "ACOPF"
 solver.name = "Ipopt"
 solver.attributes.tol = 1e-6
 solver.attributes.linear_solver = "ma27"

--- a/exp/config.toml
+++ b/exp/config.toml
@@ -23,7 +23,7 @@ factor = 5.0
 # OPF formulations to solve for each sample
 [OPF.DCOPF]
 # Formulation/solver options
-type = "DCPPowerModel"
+type = "DCOPF"
 solver.name = "Mosek"
 
 [OPF.ACOPF]

--- a/exp/config.toml
+++ b/exp/config.toml
@@ -37,8 +37,8 @@ type = "EconomicDispatch"
 kwargs.soft_thermal_limit = true
 solver.name = "Mosek"
 
-[OPF.SOCWRConic]
-type = "SOCWRConicPowerModel"
+[OPF.SOCOPF]
+type = "SOCOPF"
 solver.name = "Mosek"
 # Loosened tolerances improve Mosek's convergence
 solver.attributes.MSK_DPAR_INTPNT_CO_TOL_PFEAS = 1e-6
@@ -46,9 +46,9 @@ solver.attributes.MSK_DPAR_INTPNT_CO_TOL_DFEAS = 1e-6
 solver.attributes.MSK_DPAR_INTPNT_CO_TOL_MU_RED = 1e-6
 solver.attributes.MSK_DPAR_INTPNT_CO_TOL_REL_GAP = 1e-6
 
-[OPF.SOCWRConic128]
+[OPF.SOCOPF128]
 # These settings are meant to solve `SOCWRConic` problems to high precision
-type = "SOCWRConicPowerModel"
+type = "SOCOPF"
 solver.name = "Clarabel128"
 solver.attributes.max_iter = 2000
 solver.attributes.max_step_fraction = 0.995

--- a/exp/sampler.jl
+++ b/exp/sampler.jl
@@ -36,7 +36,7 @@ value_type(::Type{Clarabel.Optimizer{T}}) where{T} = T
 value_type(m::MOI.OptimizerWithAttributes) = value_type(m.optimizer_constructor)
 
 function build_models(data, config)
-    opf_models = Dict{String, Tuple{OPFGenerator.OPFModel{<:PowerModels.AbstractPowerModel}, Float64}}()
+    opf_models = Dict{String, Tuple{OPFGenerator.OPFModel{<:OPFGenerator.Formulation}, Float64}}()
     for (dataset_name, opf_config) in config["OPF"]
         OPF = OPFGenerator.OPF2TYPE[opf_config["type"]]
         solver_config = get(opf_config, "solver", Dict())

--- a/exp/sampler.jl
+++ b/exp/sampler.jl
@@ -36,7 +36,7 @@ value_type(::Type{Clarabel.Optimizer{T}}) where{T} = T
 value_type(m::MOI.OptimizerWithAttributes) = value_type(m.optimizer_constructor)
 
 function build_models(data, config)
-    opf_models = Dict{String, Tuple{OPFGenerator.OPFModel{<:OPFGenerator.Formulation}, Float64}}()
+    opf_models = Dict{String, Tuple{OPFGenerator.OPFModel{<:OPFGenerator.AbstractFormulation}, Float64}}()
     for (dataset_name, opf_config) in config["OPF"]
         OPF = OPFGenerator.OPF2TYPE[opf_config["type"]]
         solver_config = get(opf_config, "solver", Dict())

--- a/src/opf/acp.jl
+++ b/src/opf/acp.jl
@@ -1,3 +1,5 @@
+mutable struct ACOPF <: Formulation end
+
 """
     build_acopf(data, optimizer)
 
@@ -6,7 +8,7 @@ Build an AC-OPF model.
 This implementation is based on the AC-OPF formulation of Rosetta-OPF
     https://github.com/lanl-ansi/rosetta-opf/blob/38a951326df3156d79dcdc49c8010aa29905b05d/jump.jl
 """
-function build_opf(::Type{PM.ACPPowerModel}, data::Dict{String,Any}, optimizer;
+function build_opf(::Type{ACOPF}, data::Dict{String,Any}, optimizer;
     T=Float64,    
 )
     # Cleanup and pre-process data
@@ -33,7 +35,7 @@ function build_opf(::Type{PM.ACPPowerModel}, data::Dict{String,Any}, optimizer;
     ]
 
     model = JuMP.GenericModel{T}(optimizer)
-    model.ext[:opf_model] = PM.ACPPowerModel  # for internal checks
+    model.ext[:opf_model] = ACOPF  # for internal checks
 
     #
     #   I. Variables
@@ -160,10 +162,10 @@ function build_opf(::Type{PM.ACPPowerModel}, data::Dict{String,Any}, optimizer;
         for (i,gen) in ref[:gen]
     ))
 
-    return OPFModel{PM.ACPPowerModel}(data, model)
+    return OPFModel{ACOPF}(data, model)
 end
 
-function update!(opf::OPFModel{PM.ACPPowerModel}, data::Dict{String,Any})
+function update!(opf::OPFModel{ACOPF}, data::Dict{String,Any})
     PM.standardize_cost_terms!(data, order=2)
     PM.calc_thermal_limits!(data)
     ref = PM.build_ref(data)[:it][:pm][:nw][0]
@@ -188,7 +190,7 @@ end
 Extract ACOPF solution from optimization model.
 The model must have been solved before.
 """
-function extract_result(opf::OPFModel{PM.ACPPowerModel})
+function extract_result(opf::OPFModel{ACOPF})
     data  = opf.data
     model = opf.model
 
@@ -285,7 +287,7 @@ function extract_result(opf::OPFModel{PM.ACPPowerModel})
     return res
 end
 
-function json2h5(::Type{PM.ACPPowerModel}, res)
+function json2h5(::Type{ACOPF}, res)
     sol = res["solution"]
     N = length(sol["bus"])
     E = length(sol["branch"])

--- a/src/opf/acp.jl
+++ b/src/opf/acp.jl
@@ -1,4 +1,4 @@
-mutable struct ACOPF <: Formulation end
+struct ACOPF <: AbstractFormulation end
 
 """
     build_acopf(data, optimizer)

--- a/src/opf/dcp.jl
+++ b/src/opf/dcp.jl
@@ -1,4 +1,4 @@
-mutable struct DCOPF <: Formulation end
+struct DCOPF <: AbstractFormulation end
 
 """
     build_dcopf(data, optimizer)

--- a/src/opf/dcp.jl
+++ b/src/opf/dcp.jl
@@ -1,9 +1,11 @@
+mutable struct DCOPF <: Formulation end
+
 """
     build_dcopf(data, optimizer)
 
 Build a DC-OPF model.
 """
-function build_opf(::Type{PM.DCPPowerModel}, data::Dict{String,Any}, optimizer;
+function build_opf(::Type{DCOPF}, data::Dict{String,Any}, optimizer;
     T=Float64,    
 )
     # Cleanup and pre-process data
@@ -30,7 +32,7 @@ function build_opf(::Type{PM.DCPPowerModel}, data::Dict{String,Any}, optimizer;
     ]
 
     model = JuMP.GenericModel{T}(optimizer)
-    model.ext[:opf_model] = PM.DCPPowerModel  # for internal checks
+    model.ext[:opf_model] = DCOPF  # for internal checks
 
     #
     #   I. Variables
@@ -103,10 +105,10 @@ function build_opf(::Type{PM.DCPPowerModel}, data::Dict{String,Any}, optimizer;
         for (i,gen) in ref[:gen]
     ))
 
-    return OPFModel{PM.DCPPowerModel}(data, model)
+    return OPFModel{DCOPF}(data, model)
 end
 
-function update!(opf::OPFModel{PM.DCPPowerModel}, data::Dict{String,Any})
+function update!(opf::OPFModel{DCOPF}, data::Dict{String,Any})
     PM.standardize_cost_terms!(data, order=2)
     PM.calc_thermal_limits!(data)
     ref = PM.build_ref(data)[:it][:pm][:nw][0]
@@ -129,7 +131,7 @@ end
 Extract DCOPF solution from optimization model.
 The model must have been solved before.
 """
-function extract_result(opf::OPFModel{PM.DCPPowerModel})
+function extract_result(opf::OPFModel{DCOPF})
     data  = opf.data
     model = opf.model
 
@@ -210,7 +212,7 @@ function extract_result(opf::OPFModel{PM.DCPPowerModel})
     return res
 end
 
-function json2h5(::Type{PM.DCPPowerModel}, res)
+function json2h5(::Type{DCOPF}, res)
     sol = res["solution"]
     N = length(sol["bus"])
     E = length(sol["branch"])

--- a/src/opf/ed.jl
+++ b/src/opf/ed.jl
@@ -1,6 +1,6 @@
 using SparseArrays
 
-mutable struct EconomicDispatch <: PM.AbstractPowerModel end
+mutable struct EconomicDispatch <: Formulation end
 
 const POWER_BALANCE_PENALTY = 350000.0
 const RESERVE_SHORTAGE_PENALTY = 110000.0

--- a/src/opf/ed.jl
+++ b/src/opf/ed.jl
@@ -1,6 +1,6 @@
 using SparseArrays
 
-mutable struct EconomicDispatch <: Formulation end
+struct EconomicDispatch <: AbstractFormulation end
 
 const POWER_BALANCE_PENALTY = 350000.0
 const RESERVE_SHORTAGE_PENALTY = 110000.0

--- a/src/opf/opf.jl
+++ b/src/opf/opf.jl
@@ -278,7 +278,7 @@ include("utils.jl")
 include("acp.jl")      # ACPPowerModel
 include("dcp.jl")      # DCPPowerModel
 include("ed.jl")       # EconomicDispatch
-include("socwr.jl")    # SOCWRPowerModel & SOCWRConicPowerModel
+include("socwr.jl")    # SOCOPF & SOCOPFQuad
 
 # Contains a list of all supported OPF models
 const SUPPORTED_OPF_MODELS = Type{<:Formulation}[
@@ -286,7 +286,7 @@ const SUPPORTED_OPF_MODELS = Type{<:Formulation}[
     DCOPF,
     EconomicDispatch,
     SOCOPFQuad,
-    PowerModels.SOCWRConicPowerModel,
+    SOCOPF,
 ]
 
 # A name --> type dictionary
@@ -295,8 +295,8 @@ const OPF2TYPE = Dict{String,Type{<:Formulation}}(
     "ACOPF" => ACOPF,
     "DCOPF" => DCOPF,
     "EconomicDispatch" => EconomicDispatch,
-    "SOCWRPowerModel" => SOCOPFQuad,
-    "SOCWRConicPowerModel" => PowerModels.SOCWRConicPowerModel,
+    "SOCOPFQuad" => SOCOPFQuad,
+    "SOCOPF" => SOCOPF,
 )
 
 function solve!(opf::OPFModel{<:Formulation})

--- a/src/opf/opf.jl
+++ b/src/opf/opf.jl
@@ -282,7 +282,7 @@ include("socwr.jl")    # SOCWRPowerModel & SOCWRConicPowerModel
 
 # Contains a list of all supported OPF models
 const SUPPORTED_OPF_MODELS = Type{<:Formulation}[
-    PowerModels.ACPPowerModel,
+    ACOPF,
     PowerModels.DCPPowerModel,
     EconomicDispatch,
     PowerModels.SOCWRPowerModel,
@@ -292,7 +292,7 @@ const SUPPORTED_OPF_MODELS = Type{<:Formulation}[
 # A name --> type dictionary
 # Used for passing the OPF type as a string (e.g. through config file)
 const OPF2TYPE = Dict{String,Type{<:Formulation}}(
-    "ACPPowerModel" => PowerModels.ACPPowerModel,
+    "ACOPF" => ACOPF,
     "DCPPowerModel" => PowerModels.DCPPowerModel,
     "EconomicDispatch" => EconomicDispatch,
     "SOCWRPowerModel" => PowerModels.SOCWRPowerModel,

--- a/src/opf/opf.jl
+++ b/src/opf/opf.jl
@@ -1,9 +1,9 @@
 using MathOptSymbolicAD
 using SparseArrays
 
-abstract type Formulation end
+abstract type AbstractFormulation end
 
-mutable struct OPFModel{OPF <: Formulation}
+mutable struct OPFModel{OPF <: AbstractFormulation}
     data::Dict{String,Any}
     model::JuMP.GenericModel
 end
@@ -281,7 +281,7 @@ include("ed.jl")       # EconomicDispatch
 include("socwr.jl")    # SOCOPF & SOCOPFQuad
 
 # Contains a list of all supported OPF models
-const SUPPORTED_OPF_MODELS = Type{<:Formulation}[
+const SUPPORTED_OPF_MODELS = Type{<:AbstractFormulation}[
     ACOPF,
     DCOPF,
     EconomicDispatch,
@@ -291,7 +291,7 @@ const SUPPORTED_OPF_MODELS = Type{<:Formulation}[
 
 # A name --> type dictionary
 # Used for passing the OPF type as a string (e.g. through config file)
-const OPF2TYPE = Dict{String,Type{<:Formulation}}(
+const OPF2TYPE = Dict{String,Type{<:AbstractFormulation}}(
     "ACOPF" => ACOPF,
     "DCOPF" => DCOPF,
     "EconomicDispatch" => EconomicDispatch,
@@ -299,6 +299,6 @@ const OPF2TYPE = Dict{String,Type{<:Formulation}}(
     "SOCOPF" => SOCOPF,
 )
 
-function solve!(opf::OPFModel{<:Formulation})
+function solve!(opf::OPFModel{<:AbstractFormulation})
     optimize!(opf.model; _differentiation_backend = MathOptSymbolicAD.DefaultBackend())
 end

--- a/src/opf/opf.jl
+++ b/src/opf/opf.jl
@@ -1,7 +1,9 @@
 using MathOptSymbolicAD
 using SparseArrays
 
-mutable struct OPFModel{OPF <: PM.AbstractPowerModel}
+abstract type Formulation end
+
+mutable struct OPFModel{OPF <: Formulation}
     data::Dict{String,Any}
     model::JuMP.GenericModel
 end
@@ -279,7 +281,7 @@ include("ed.jl")       # EconomicDispatch
 include("socwr.jl")    # SOCWRPowerModel & SOCWRConicPowerModel
 
 # Contains a list of all supported OPF models
-const SUPPORTED_OPF_MODELS = Type{<:AbstractPowerModel}[
+const SUPPORTED_OPF_MODELS = Type{<:Formulation}[
     PowerModels.ACPPowerModel,
     PowerModels.DCPPowerModel,
     EconomicDispatch,
@@ -289,7 +291,7 @@ const SUPPORTED_OPF_MODELS = Type{<:AbstractPowerModel}[
 
 # A name --> type dictionary
 # Used for passing the OPF type as a string (e.g. through config file)
-const OPF2TYPE = Dict{String,Type{<:AbstractPowerModel}}(
+const OPF2TYPE = Dict{String,Type{<:Formulation}}(
     "ACPPowerModel" => PowerModels.ACPPowerModel,
     "DCPPowerModel" => PowerModels.DCPPowerModel,
     "EconomicDispatch" => EconomicDispatch,
@@ -297,6 +299,6 @@ const OPF2TYPE = Dict{String,Type{<:AbstractPowerModel}}(
     "SOCWRConicPowerModel" => PowerModels.SOCWRConicPowerModel,
 )
 
-function solve!(opf::OPFModel{<:AbstractPowerModel})
+function solve!(opf::OPFModel{<:Formulation})
     optimize!(opf.model; _differentiation_backend = MathOptSymbolicAD.DefaultBackend())
 end

--- a/src/opf/opf.jl
+++ b/src/opf/opf.jl
@@ -283,7 +283,7 @@ include("socwr.jl")    # SOCWRPowerModel & SOCWRConicPowerModel
 # Contains a list of all supported OPF models
 const SUPPORTED_OPF_MODELS = Type{<:Formulation}[
     ACOPF,
-    PowerModels.DCPPowerModel,
+    DCOPF,
     EconomicDispatch,
     PowerModels.SOCWRPowerModel,
     PowerModels.SOCWRConicPowerModel,
@@ -293,7 +293,7 @@ const SUPPORTED_OPF_MODELS = Type{<:Formulation}[
 # Used for passing the OPF type as a string (e.g. through config file)
 const OPF2TYPE = Dict{String,Type{<:Formulation}}(
     "ACOPF" => ACOPF,
-    "DCPPowerModel" => PowerModels.DCPPowerModel,
+    "DCOPF" => DCOPF,
     "EconomicDispatch" => EconomicDispatch,
     "SOCWRPowerModel" => PowerModels.SOCWRPowerModel,
     "SOCWRConicPowerModel" => PowerModels.SOCWRConicPowerModel,

--- a/src/opf/opf.jl
+++ b/src/opf/opf.jl
@@ -285,7 +285,7 @@ const SUPPORTED_OPF_MODELS = Type{<:Formulation}[
     ACOPF,
     DCOPF,
     EconomicDispatch,
-    PowerModels.SOCWRPowerModel,
+    SOCOPFQuad,
     PowerModels.SOCWRConicPowerModel,
 ]
 
@@ -295,7 +295,7 @@ const OPF2TYPE = Dict{String,Type{<:Formulation}}(
     "ACOPF" => ACOPF,
     "DCOPF" => DCOPF,
     "EconomicDispatch" => EconomicDispatch,
-    "SOCWRPowerModel" => PowerModels.SOCWRPowerModel,
+    "SOCWRPowerModel" => SOCOPFQuad,
     "SOCWRConicPowerModel" => PowerModels.SOCWRConicPowerModel,
 )
 

--- a/src/opf/socwr.jl
+++ b/src/opf/socwr.jl
@@ -1,5 +1,5 @@
-mutable struct SOCOPFQuad <: Formulation end
-mutable struct SOCOPF <: Formulation end
+struct SOCOPFQuad <: AbstractFormulation end
+struct SOCOPF <: AbstractFormulation end
 
 """
     build_soc_opf(data, optimizer)

--- a/src/opf/socwr.jl
+++ b/src/opf/socwr.jl
@@ -1,4 +1,5 @@
 mutable struct SOCOPFQuad <: Formulation end
+mutable struct SOCOPF <: Formulation end
 
 """
     build_soc_opf(data, optimizer)
@@ -10,7 +11,7 @@ This implementation is based on the SOC-OPF formulation of PMAnnex.jl
 """
 function build_opf(::Type{OPF}, data::Dict{String,Any}, optimizer;
     T=Float64,
-) where {OPF <: Union{SOCOPFQuad,PM.SOCWRConicPowerModel}}
+) where {OPF <: Union{SOCOPFQuad,SOCOPF}}
     @assert !haskey(data, "multinetwork")
     @assert !haskey(data, "conductors")
 
@@ -164,7 +165,7 @@ function build_opf(::Type{OPF}, data::Dict{String,Any}, optimizer;
         if OPF == SOCOPFQuad
             model[:thermal_limit_fr][i] = JuMP.@constraint(model, p_fr^2 + q_fr^2 <= branch["rate_a"]^2)
             model[:thermal_limit_to][i] = JuMP.@constraint(model, p_to^2 + q_to^2 <= branch["rate_a"]^2)
-        elseif OPF == PM.SOCWRConicPowerModel
+        elseif OPF == SOCOPF
             model[:thermal_limit_fr][i] = JuMP.@constraint(model, [branch["rate_a"], p_fr, q_fr] in JuMP.SecondOrderCone())
             model[:thermal_limit_to][i] = JuMP.@constraint(model, [branch["rate_a"], p_to, q_to] in JuMP.SecondOrderCone())
         end
@@ -174,7 +175,7 @@ function build_opf(::Type{OPF}, data::Dict{String,Any}, optimizer;
             model[:jabr][i] = JuMP.@constraint(model,
                 wr[i]^2 + wi[i]^2 <= w[branch["f_bus"]]*w[branch["t_bus"]]
             )
-        elseif OPF == PM.SOCWRConicPowerModel
+        elseif OPF == SOCOPF
             model[:jabr][i] = JuMP.@constraint(model,
                 [w[branch["f_bus"]] / sqrt(2), w[branch["t_bus"]] / sqrt(2), wr[i], wi[i]] in JuMP.RotatedSecondOrderCone()
             )
@@ -194,7 +195,7 @@ function build_opf(::Type{OPF}, data::Dict{String,Any}, optimizer;
     return OPFModel{OPF}(data, model)
 end
 
-function update!(opf::OPFModel{OPF}, data::Dict{String,Any}) where {OPF <: Union{SOCOPFQuad,PM.SOCWRConicPowerModel}}
+function update!(opf::OPFModel{OPF}, data::Dict{String,Any}) where {OPF <: Union{SOCOPFQuad,SOCOPF}}
     PM.standardize_cost_terms!(data, order=2)
     PM.calc_thermal_limits!(data)
     ref = PM.build_ref(data)[:it][:pm][:nw][0]
@@ -218,7 +219,7 @@ end
 Extract SOC-OPF solution from optimization model.
 The model must have been solved before.
 """
-function extract_result(opf::OPFModel{OPF}) where {OPF <: Union{SOCOPFQuad,PM.SOCWRConicPowerModel}}
+function extract_result(opf::OPFModel{OPF}) where {OPF <: Union{SOCOPFQuad,SOCOPF}}
     data  = opf.data
     model = opf.model
 
@@ -288,7 +289,7 @@ function extract_result(opf::OPFModel{OPF}) where {OPF <: Union{SOCOPFQuad,PM.SO
                 brsol["mu_sm_to"] = 0.0
                 brsol["mu_sm_fr"] = 0.0
                 brsol["mu_jabr"] = 0.0
-            elseif OPF == PM.SOCWRConicPowerModel
+            elseif OPF == SOCOPF
                 # conic duals (vector-shaped)
                 brsol["nu_jabr"] = [0.0, 0.0, 0.0, 0.0]
                 brsol["nu_sm_to"] = [0.0, 0.0, 0.0]
@@ -321,7 +322,7 @@ function extract_result(opf::OPFModel{OPF}) where {OPF <: Union{SOCOPFQuad,PM.SO
                 brsol["mu_sm_to"] = dual(model[:thermal_limit_to][b])
                 brsol["mu_sm_fr"] = dual(model[:thermal_limit_fr][b])
                 brsol["mu_jabr"] = dual(model[:jabr][b])
-            elseif OPF == PM.SOCWRConicPowerModel
+            elseif OPF == SOCOPF
                 brsol["nu_jabr"] = dual(model[:jabr][b])
                 brsol["nu_sm_to"] = dual(model[:thermal_limit_to][b])
                 brsol["nu_sm_fr"] = dual(model[:thermal_limit_fr][b])
@@ -344,7 +345,7 @@ function extract_result(opf::OPFModel{OPF}) where {OPF <: Union{SOCOPFQuad,PM.SO
     return res
 end
 
-function json2h5(::Type{OPF}, res) where{OPF <: Union{SOCOPFQuad,PM.SOCWRConicPowerModel}}
+function json2h5(::Type{OPF}, res) where{OPF <: Union{SOCOPFQuad,SOCOPF}}
     sol = res["solution"]
     N = length(sol["bus"])
     E = length(sol["branch"])
@@ -398,7 +399,7 @@ function json2h5(::Type{OPF}, res) where{OPF <: Union{SOCOPFQuad,PM.SOCWRConicPo
         dres_h5["mu_sm_to"] = zeros(Float64, E)
         dres_h5["mu_sm_fr"] = zeros(Float64, E)
         dres_h5["mu_jabr"] = zeros(Float64, E)
-    elseif OPF == PM.SOCWRConicPowerModel
+    elseif OPF == SOCOPF
         # conic duals (unrolled)
         dres_h5["nu_jabr"] = zeros(Float64, E, 4)
         dres_h5["nu_sm_to"] = zeros(Float64, E, 3)
@@ -453,7 +454,7 @@ function json2h5(::Type{OPF}, res) where{OPF <: Union{SOCOPFQuad,PM.SOCWRConicPo
             dres_h5["mu_sm_to"][e] = brsol["mu_sm_to"]
             dres_h5["mu_sm_fr"][e] = brsol["mu_sm_fr"]
             dres_h5["mu_jabr"][e] = brsol["mu_jabr"]
-        elseif OPF == PM.SOCWRConicPowerModel
+        elseif OPF == SOCOPF
             # conic duals (unrolled)
             dres_h5["nu_jabr"][e, :] .= brsol["nu_jabr"]
             dres_h5["nu_sm_to"][e, :] .= brsol["nu_sm_to"]

--- a/test/opf/acp.jl
+++ b/test/opf/acp.jl
@@ -1,5 +1,5 @@
-function test_opf_pm(::Type{PM.ACPPowerModel}, data::Dict)
-    OPF = PM.ACPPowerModel
+function test_opf_pm(::Type{OPFGenerator.ACOPF}, data::Dict)
+    OPF = OPFGenerator.ACOPF
     # Sanity checks
     data["basic_network"] || error("Input data must be in basic format to test")
     N = length(data["bus"])
@@ -8,7 +8,7 @@ function test_opf_pm(::Type{PM.ACPPowerModel}, data::Dict)
 
     # Solve OPF with PowerModels
     solver = OPT_SOLVERS[OPF]
-    res_pm = PM.solve_opf(data, OPF, solver)
+    res_pm = PM.solve_opf(data, PM.ACPPowerModel, solver)
 
     # Build and solve OPF with OPFGenerator
     solver = OPT_SOLVERS[OPF]

--- a/test/opf/dcp.jl
+++ b/test/opf/dcp.jl
@@ -1,5 +1,5 @@
-function test_opf_pm(::Type{PM.DCPPowerModel}, data::Dict)
-    OPF = PM.DCPPowerModel
+function test_opf_pm(::Type{OPFGenerator.DCOPF}, data::Dict)
+    OPF = OPFGenerator.DCOPF
 
     data["basic_network"] || error("Input data must be in basic format to test")
     N = length(data["bus"])
@@ -8,7 +8,7 @@ function test_opf_pm(::Type{PM.DCPPowerModel}, data::Dict)
 
     # Solve OPF with PowerModels
     solver = OPT_SOLVERS[OPF]
-    res_pm = PM.solve_opf(data, OPF, solver)
+    res_pm = PM.solve_opf(data, PM.DCPPowerModel, solver)
 
     # Build and solve OPF with OPFGenerator
     solver = OPT_SOLVERS[OPF]

--- a/test/opf/opf.jl
+++ b/test/opf/opf.jl
@@ -2,7 +2,7 @@ using OPFGenerator: OPFData
 
 include("utils.jl")
 
-function test_opf_pm(OPF::Type{<:PM.AbstractPowerModel}, casename::String)
+function test_opf_pm(OPF::Type{<:OPFGenerator.Formulation}, casename::String)
     network = make_basic_network(pglib(casename))
     test_opf_pm(OPF, network)
 end
@@ -12,7 +12,7 @@ end
 
 Build & solve opf using OPFGenerator, and compare against PowerModels implementation.
 """
-function test_opf_pm(::Type{OPF}, data::Dict) where{OPF <: Formulation}
+function test_opf_pm(::Type{OPF}, data::Dict) where{OPF <: OPFGenerator.Formulation}
     error("""`test_opf_pm($(OPF), data)` not implemented.
     You must implement a function with the following signature:
         function test_opf_pm(::Type{OPF}, data::Dict) where{OPF <: $(OPF)}

--- a/test/opf/opf.jl
+++ b/test/opf/opf.jl
@@ -12,7 +12,7 @@ end
 
 Build & solve opf using OPFGenerator, and compare against PowerModels implementation.
 """
-function test_opf_pm(::Type{OPF}, data::Dict) where{OPF <: PM.AbstractPowerModel}
+function test_opf_pm(::Type{OPF}, data::Dict) where{OPF <: Formulation}
     error("""`test_opf_pm($(OPF), data)` not implemented.
     You must implement a function with the following signature:
         function test_opf_pm(::Type{OPF}, data::Dict) where{OPF <: $(OPF)}

--- a/test/opf/opf.jl
+++ b/test/opf/opf.jl
@@ -2,7 +2,7 @@ using OPFGenerator: OPFData
 
 include("utils.jl")
 
-function test_opf_pm(OPF::Type{<:OPFGenerator.Formulation}, casename::String)
+function test_opf_pm(OPF::Type{<:OPFGenerator.AbstractFormulation}, casename::String)
     network = make_basic_network(pglib(casename))
     test_opf_pm(OPF, network)
 end
@@ -12,7 +12,7 @@ end
 
 Build & solve opf using OPFGenerator, and compare against PowerModels implementation.
 """
-function test_opf_pm(::Type{OPF}, data::Dict) where{OPF <: OPFGenerator.Formulation}
+function test_opf_pm(::Type{OPF}, data::Dict) where{OPF <: OPFGenerator.AbstractFormulation}
     error("""`test_opf_pm($(OPF), data)` not implemented.
     You must implement a function with the following signature:
         function test_opf_pm(::Type{OPF}, data::Dict) where{OPF <: $(OPF)}

--- a/test/opf/socwr.jl
+++ b/test/opf/socwr.jl
@@ -6,7 +6,7 @@ function test_opf_pm(::Type{OPF}, data::Dict) where {OPF <: Union{OPFGenerator.S
     E = length(data["branch"])
     G = length(data["gen"])
 
-    pm_type = OPF == SOCOPF ? PM.SOCWRConicPowerModel : PM.SOCWRPowerModel
+    pm_type = OPF == OPFGenerator.SOCOPF ? PM.SOCWRConicPowerModel : PM.SOCWRPowerModel
 
     # Solve OPF with PowerModels
     solver = OPT_SOLVERS[OPF]
@@ -27,7 +27,7 @@ function test_opf_pm(::Type{OPF}, data::Dict) where {OPF <: Union{OPFGenerator.S
     #   because our SOC formulation is not equivalent
     # Check that primal/dual objectives are matching only for conic form
     #   (Ipopt is not good with dual objective value)
-    if OPF == PM.SOCWRConicPowerModel
+    if OPF == OPFGenerator.SOCOPF
         @test isapprox(res["objective"], res["objective_lb"], rtol=1e-6)
     end
 
@@ -77,7 +77,7 @@ function _test_socwr_DualFeasibility()
         "tol_infeas_rel" => 1e-14,
         "tol_ktratio"    => 1e-14,
     )
-    opf = OPFGenerator.build_opf(SOCWRConicPowerModel, data, solver; T=T)
+    opf = OPFGenerator.build_opf(OPFGenerator.SOCOPF, data, solver; T=T)
     # set_silent(opf.model)
     OPFGenerator.solve!(opf)
     res = OPFGenerator.extract_result(opf)
@@ -219,7 +219,7 @@ function _test_socwr_DualSolFormat()
     E = length(data["branch"])
 
     solver = CLRBL_SOLVER
-    opf = OPFGenerator.build_opf(SOCWRConicPowerModel, data, solver)
+    opf = OPFGenerator.build_opf(OPFGenerator.SOCOPF, data, solver)
     set_silent(opf.model)
     OPFGenerator.solve!(opf)
 
@@ -230,7 +230,7 @@ function _test_socwr_DualSolFormat()
     @test size(res["solution"]["branch"]["1"]["nu_sm_fr"]) == (3,)
 
     # Check conversion to H5 format
-    h5 = OPFGenerator.json2h5(SOCWRConicPowerModel, res)
+    h5 = OPFGenerator.json2h5(OPFGenerator.SOCOPF, res)
 
     @test Set(collect(keys(h5))) == Set(["meta", "primal", "dual"])
     @test size(h5["dual"]["nu_jabr"]) == (E, 4)
@@ -240,7 +240,7 @@ function _test_socwr_DualSolFormat()
 end
 
 function _test_socwr128(data::Dict)
-    opf = OPFGenerator.build_opf(PM.SOCWRConicPowerModel, data, CLRBL128_SOLVER; T=Float128)
+    opf = OPFGenerator.build_opf(OPFGenerator.SOCOPF, data, CLRBL128_SOLVER; T=Float128)
 
     OPFGenerator.solve!(opf)
 

--- a/test/opf/socwr.jl
+++ b/test/opf/socwr.jl
@@ -1,14 +1,16 @@
 using LinearAlgebra
 
-function test_opf_pm(::Type{OPF}, data::Dict) where {OPF <: Union{PM.SOCWRPowerModel,PM.SOCWRConicPowerModel}}
+function test_opf_pm(::Type{OPF}, data::Dict) where {OPF <: Union{OPFGenerator.SOCOPFQuad,OPFGenerator.SOCOPF}}
     data["basic_network"] || error("Input data must be in basic format to test")
     N = length(data["bus"])
     E = length(data["branch"])
     G = length(data["gen"])
 
+    pm_type = OPF == SOCOPF ? PM.SOCWRConicPowerModel : PM.SOCWRPowerModel
+
     # Solve OPF with PowerModels
     solver = OPT_SOLVERS[OPF]
-    res_pm = PM.solve_opf(data, OPF, solver)
+    res_pm = PM.solve_opf(data, pm_type, solver)
 
     # Build and solve OPF with OPFGenerator
     solver = OPT_SOLVERS[OPF]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,8 +29,8 @@ const OPT_SOLVERS = Dict(
     OPFGenerator.EconomicDispatch  => CLRBL_SOLVER,
 )
 
-# include("io.jl")
-# include("bridges.jl")
-# include("sampler.jl")
+include("io.jl")
+include("bridges.jl")
+include("sampler.jl")
 include("opf/opf.jl")
 include("postprocess.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,10 +22,10 @@ const CLRBL128_SOLVER = JuMP.optimizer_with_attributes(Clarabel.Optimizer{Float1
 )
 
 const OPT_SOLVERS = Dict(
-    OPFGenerator.ACOPF               => IPOPT_SOLVER,
-    OPFGenerator.SOCOPFQuad             => IPOPT_SOLVER,
-    OPFGenerator.SOCOPF        => CLRBL_SOLVER,
-    OPFGenerator.DCOPF               => CLRBL_SOLVER,
+    OPFGenerator.ACOPF             => IPOPT_SOLVER,
+    OPFGenerator.SOCOPFQuad        => IPOPT_SOLVER,
+    OPFGenerator.SOCOPF            => CLRBL_SOLVER,
+    OPFGenerator.DCOPF             => CLRBL_SOLVER,
     OPFGenerator.EconomicDispatch  => CLRBL_SOLVER,
 )
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,7 +23,7 @@ const CLRBL128_SOLVER = JuMP.optimizer_with_attributes(Clarabel.Optimizer{Float1
 
 const OPT_SOLVERS = Dict(
     OPFGenerator.ACOPF               => IPOPT_SOLVER,
-    PM.SOCWRPowerModel             => IPOPT_SOLVER,
+    OPFGenerator.SOCOPFQuad             => IPOPT_SOLVER,
     PM.SOCWRConicPowerModel        => CLRBL_SOLVER,
     OPFGenerator.DCOPF               => CLRBL_SOLVER,
     OPFGenerator.EconomicDispatch  => CLRBL_SOLVER,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,15 +22,15 @@ const CLRBL128_SOLVER = JuMP.optimizer_with_attributes(Clarabel.Optimizer{Float1
 )
 
 const OPT_SOLVERS = Dict(
-    PM.ACPPowerModel               => IPOPT_SOLVER,
+    OPFGenerator.ACOPF               => IPOPT_SOLVER,
     PM.SOCWRPowerModel             => IPOPT_SOLVER,
     PM.SOCWRConicPowerModel        => CLRBL_SOLVER,
     PM.DCPPowerModel               => CLRBL_SOLVER,
     OPFGenerator.EconomicDispatch  => CLRBL_SOLVER,
 )
 
-include("io.jl")
-include("bridges.jl")
-include("sampler.jl")
+# include("io.jl")
+# include("bridges.jl")
+# include("sampler.jl")
 include("opf/opf.jl")
 include("postprocess.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,7 +24,7 @@ const CLRBL128_SOLVER = JuMP.optimizer_with_attributes(Clarabel.Optimizer{Float1
 const OPT_SOLVERS = Dict(
     OPFGenerator.ACOPF               => IPOPT_SOLVER,
     OPFGenerator.SOCOPFQuad             => IPOPT_SOLVER,
-    PM.SOCWRConicPowerModel        => CLRBL_SOLVER,
+    OPFGenerator.SOCOPF        => CLRBL_SOLVER,
     OPFGenerator.DCOPF               => CLRBL_SOLVER,
     OPFGenerator.EconomicDispatch  => CLRBL_SOLVER,
 )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,7 +25,7 @@ const OPT_SOLVERS = Dict(
     OPFGenerator.ACOPF               => IPOPT_SOLVER,
     PM.SOCWRPowerModel             => IPOPT_SOLVER,
     PM.SOCWRConicPowerModel        => CLRBL_SOLVER,
-    PM.DCPPowerModel               => CLRBL_SOLVER,
+    OPFGenerator.DCOPF               => CLRBL_SOLVER,
     OPFGenerator.EconomicDispatch  => CLRBL_SOLVER,
 )
 

--- a/test/sampler.jl
+++ b/test/sampler.jl
@@ -287,7 +287,7 @@ function test_update()
 end
 
 
-function _test_update(::Type{DCOPF}, opf1, opf2)
+function _test_update(::Type{OPFGenerator.DCOPF}, opf1, opf2)
     @test all(normalized_rhs.(opf1.model[:kirchhoff]) .== normalized_rhs.(opf2.model[:kirchhoff]))
 end
 

--- a/test/sampler.jl
+++ b/test/sampler.jl
@@ -287,7 +287,7 @@ function test_update()
 end
 
 
-function _test_update(::Type{PM.DCPPowerModel}, opf1, opf2)
+function _test_update(::Type{DCOPF}, opf1, opf2)
     @test all(normalized_rhs.(opf1.model[:kirchhoff]) .== normalized_rhs.(opf2.model[:kirchhoff]))
 end
 
@@ -332,7 +332,7 @@ function test_sampler_script()
         ),
         "OPF" => Dict(
             "DCOPF" => Dict(
-                "type" => "DCPPowerModel",
+                "type" => "DCOPF",
                 "solver" => Dict(
                     "name" => "Clarabel",
                 )

--- a/test/sampler.jl
+++ b/test/sampler.jl
@@ -291,7 +291,7 @@ function _test_update(::Type{DCOPF}, opf1, opf2)
     @test all(normalized_rhs.(opf1.model[:kirchhoff]) .== normalized_rhs.(opf2.model[:kirchhoff]))
 end
 
-function _test_update(::Type{OPF}, opf1, opf2) where {OPF <: Union{OPFGenerator.ACOPF, PM.SOCWRPowerModel, PM.SOCWRConicPowerModel}}
+function _test_update(::Type{OPF}, opf1, opf2) where {OPF <: Union{OPFGenerator.ACOPF, OPFGenerator.SOCOPFQuad, PM.SOCWRConicPowerModel}}
     @test all(normalized_rhs.(opf1.model[:kirchhoff_active]) .== normalized_rhs.(opf2.model[:kirchhoff_active]))
     @test all(normalized_rhs.(opf1.model[:kirchhoff_reactive]) .== normalized_rhs.(opf2.model[:kirchhoff_reactive]))
 end

--- a/test/sampler.jl
+++ b/test/sampler.jl
@@ -291,7 +291,7 @@ function _test_update(::Type{PM.DCPPowerModel}, opf1, opf2)
     @test all(normalized_rhs.(opf1.model[:kirchhoff]) .== normalized_rhs.(opf2.model[:kirchhoff]))
 end
 
-function _test_update(::Type{OPF}, opf1, opf2) where {OPF <: Union{PM.ACPPowerModel, PM.SOCWRPowerModel, PM.SOCWRConicPowerModel}}
+function _test_update(::Type{OPF}, opf1, opf2) where {OPF <: Union{OPFGenerator.ACOPF, PM.SOCWRPowerModel, PM.SOCWRConicPowerModel}}
     @test all(normalized_rhs.(opf1.model[:kirchhoff_active]) .== normalized_rhs.(opf2.model[:kirchhoff_active]))
     @test all(normalized_rhs.(opf1.model[:kirchhoff_reactive]) .== normalized_rhs.(opf2.model[:kirchhoff_reactive]))
 end
@@ -338,7 +338,7 @@ function test_sampler_script()
                 )
             ),
             "ACOPF" => Dict(
-                "type" => "ACPPowerModel",
+                "type" => "ACOPF",
                 "solver" => Dict(
                     "name" => "Ipopt",
                     "attributes" => Dict(

--- a/test/sampler.jl
+++ b/test/sampler.jl
@@ -291,7 +291,7 @@ function _test_update(::Type{DCOPF}, opf1, opf2)
     @test all(normalized_rhs.(opf1.model[:kirchhoff]) .== normalized_rhs.(opf2.model[:kirchhoff]))
 end
 
-function _test_update(::Type{OPF}, opf1, opf2) where {OPF <: Union{OPFGenerator.ACOPF, OPFGenerator.SOCOPFQuad, PM.SOCWRConicPowerModel}}
+function _test_update(::Type{OPF}, opf1, opf2) where {OPF <: Union{OPFGenerator.ACOPF, OPFGenerator.SOCOPFQuad, OPFGenerator.SOCOPF}}
     @test all(normalized_rhs.(opf1.model[:kirchhoff_active]) .== normalized_rhs.(opf2.model[:kirchhoff_active]))
     @test all(normalized_rhs.(opf1.model[:kirchhoff_reactive]) .== normalized_rhs.(opf2.model[:kirchhoff_reactive]))
 end
@@ -361,14 +361,14 @@ function test_sampler_script()
                     "name" => "Clarabel",
                 )
             ),
-            "SOCWRConic" => Dict(
-                "type" => "SOCWRConicPowerModel",
+            "SOCOPF" => Dict(
+                "type" => "SOCOPF",
                 "solver" => Dict(
                     "name" => "Clarabel",
                 )
             ),
-            "SOCWRConic128" => Dict(
-                "type" => "SOCWRConicPowerModel",
+            "SOCOPF128" => Dict(
+                "type" => "SOCOPF",
                 "solver" => Dict(
                     "name" => "Clarabel128",
                     "attributes" => Dict(


### PR DESCRIPTION
This PR introduces our own type system:

`PM.AbstractPowerModel -> AbstractFormulation`
`PM.ACPPowerModel -> ACOPF`
`PM.DCPPowerModel -> DCOPF`
`PM.SOCWRConicPowerModel -> SOCOPF`
`PM.SOCWRPowerModel -> SOCOPFQuad`
