### PR TITLE
EconomicDispatch with OPFData

### DIFF
--- a/exp/config.toml
+++ b/exp/config.toml
@@ -40,6 +40,11 @@ type = "EconomicDispatch"
 kwargs.soft_thermal_limit = true
 solver.name = "Mosek"
 
+[OPF.EDR]
+type = "EconomicDispatchWithReserves"
+kwargs.soft_thermal_limit = true
+solver.name = "Mosek"
+
 [OPF.SOCOPF]
 type = "SOCOPF"
 solver.name = "Mosek"

--- a/exp/config.toml
+++ b/exp/config.toml
@@ -40,11 +40,6 @@ type = "EconomicDispatch"
 kwargs.soft_thermal_limit = true
 solver.name = "Mosek"
 
-[OPF.EDR]
-type = "EconomicDispatchWithReserves"
-kwargs.soft_thermal_limit = true
-solver.name = "Mosek"
-
 [OPF.SOCOPF]
 type = "SOCOPF"
 solver.name = "Mosek"

--- a/src/opf/ed.jl
+++ b/src/opf/ed.jl
@@ -1,193 +1,172 @@
 using SparseArrays
 
 struct EconomicDispatch <: AbstractFormulation end
+struct EconomicDispatchWithReserves <: AbstractFormulation end
 
-const POWER_BALANCE_PENALTY = 350000.0
-const RESERVE_SHORTAGE_PENALTY = 110000.0
 const THERMAL_PENALTY = 150000.0
 const MAX_PTDF_ITERATIONS = 128
 const MAX_PTDF_PER_ITERATION = 8
 const ITERATIVE_PTDF_TOL = 1e-6
 
-function build_opf(::Type{EconomicDispatch}, data::Dict{String,Any}, optimizer;
+function build_opf(::Type{OPF}, network::Dict{String,Any}, optimizer;
     T=Float64,
-    soft_power_balance::Bool=false,
-    soft_reserve_requirement::Bool=false,
     soft_thermal_limit::Bool=false,
-    power_balance_penalty=POWER_BALANCE_PENALTY,
-    reserve_shortage_penalty=RESERVE_SHORTAGE_PENALTY,
     thermal_penalty=THERMAL_PENALTY,
-    iterative_ptdf::Bool=true,
     iterative_ptdf_tol=ITERATIVE_PTDF_TOL,
     max_ptdf_iterations=MAX_PTDF_ITERATIONS,
     max_ptdf_per_iteration=MAX_PTDF_PER_ITERATION,
-)
-    # Cleanup and pre-process data
-    PM.standardize_cost_terms!(data, order=2)
-    PM.calc_thermal_limits!(data)
-    ref = PM.build_ref(data)[:it][:pm][:nw][0]
+) where {OPF <: Union{EconomicDispatch, EconomicDispatchWithReserves}}
+    # TODO: remove when all formulations are done
+    data = OPFData(network)
 
-    # Check that slack bus is unique
-    length(ref[:ref_buses]) == 1 || error("Data has $(length(ref[:ref_buses])) slack buses (expected 1).")
-    i0 = first(keys(ref[:ref_buses]))
-
-    power_balance_penalty >= 0.0 || error("EconomicDispatch option power_balance_penalty must be non-negative")
-    reserve_shortage_penalty >= 0.0 || error("EconomicDispatch option reserve_shortage_penalty must be non-negative")
-    thermal_penalty >= 0.0 || error("EconomicDispatch option transmission_penalty must be non-negative")
-    max_ptdf_iterations > 0 || error("EconomicDispatch option max_ptdf_iterations must be a positive integer")
-    max_ptdf_per_iteration > 0 || error("EconomicDispatch option max_ptdf_per_iteration must be a positive integer")
+    thermal_penalty >= 0.0 || error("$OPF option transmission_penalty must be non-negative")
+    max_ptdf_iterations > 0 || error("$OPF option max_ptdf_iterations must be a positive integer")
+    max_ptdf_per_iteration > 0 || error("$OPF option max_ptdf_per_iteration must be a positive integer")
 
     # Grab some data
-    N = length(ref[:bus])
-    G = length(ref[:gen])
-    E = length(ref[:branch])
-    L = length(ref[:load])
+    E, G = data.E, data.G
+    pgmin, pgmax = data.pgmin, data.pgmax
+    c0, c1, c2 = data.c0, data.c1, data.c2
+    smax = data.smax
+    branch_status, gen_status = data.branch_status, data.gen_status
 
-    pmin = [ref[:gen][g]["pmin"] for g in 1:G]
-    pmax = [ref[:gen][g]["pmax"] for g in 1:G]
-    PD = sum(ref[:load][l]["pd"] for l in 1:L)
-    pfmax = [data["branch"]["$e"]["rate_a"] for e in 1:E]
+    all(branch_status) || error("$OPF does not support disabled branches.")
 
-    minimum_reserve = get(data, "minimum_reserve", 0.0)
-    # if minimum reserve is zero, rmin = rmax = 0 to fix the reserve variables to zero.
-    # otherwise, rmin and rmax must be present in the data (not standard in PGLib)
-    rmin = (minimum_reserve > 0.0) ? [ref[:gen][g]["rmin"] for g in 1:G] : zeros(T, G)
-    rmax = (minimum_reserve > 0.0) ? [ref[:gen][g]["rmax"] for g in 1:G] : zeros(T, G)
+    PD = sum(data.pd) # total demand
+
+    # reserves data
+    MRR = data.minimum_reserve
+    rmin = data.rmin
+    rmax = data.rmax
 
     model = JuMP.GenericModel{T}(optimizer)
-    model.ext[:opf_model] = EconomicDispatch  # for internal checks
+    model.ext[:opf_model] = OPF
     model.ext[:solve_metadata] = Dict{Symbol,Any}(
-        :iterative_ptdf => iterative_ptdf,
         :iterative_ptdf_tol => iterative_ptdf_tol,
         :max_ptdf_iterations => max_ptdf_iterations,
         :max_ptdf_per_iteration => max_ptdf_per_iteration,
     )
 
-    # Variables
+    #
+    #   I. Variables
+    #
 
-    JuMP.@variable(model, pmin[g] <= pg[g in 1:G] <= pmax[g])
-    JuMP.@variable(model, rmin[g] <= r[g in 1:G] <= rmax[g])
-    JuMP.@variable(model, pf[e in 1:E])
+    # Active dispatch
+    @variable(model, pg[g in 1:G])
 
-    JuMP.@variable(model, δpb_surplus >= 0)
-    JuMP.@variable(model, δpb_shortage >= 0)
-    JuMP.@variable(model, δr_shortage >= 0)
-    JuMP.@variable(model, δf[1:E] >= 0)
-
-    JuMP.@constraint(model,
-        pf_lower_bound[e in 1:E],
-        pf[e] + δf[e] >= -pfmax[e] 
-    )
-    JuMP.@constraint(model,
-        pf_upper_bound[e in 1:E],
-        pf[e] - δf[e] <= pfmax[e] 
-    )
-
-    if !soft_power_balance
-        JuMP.set_upper_bound(δpb_surplus, 0)
-        JuMP.set_upper_bound(δpb_shortage, 0)
+    if OPF == EconomicDispatchWithReserves
+        # Active reserves
+        @variable(model, r[g in 1:G])
     end
 
-    if !soft_reserve_requirement && minimum_reserve > 0.0
-        JuMP.set_upper_bound(δr_shortage, 0)
+    # Active branch flow
+    @variable(model, pf[e in 1:E])
+
+    # Active branch flow slack
+    @variable(model, δf[1:E] >= 0)
+
+    # 
+    #   II. Constraints
+    #
+
+    # Generation bounds (zero if generator is off)
+    set_lower_bound.(pg, gen_status .* pgmin)
+    set_upper_bound.(pg, gen_status .* pgmax)
+
+    if OPF == EconomicDispatchWithReserves
+        # Reserve bounds (zero if generator is off)
+        set_lower_bound.(r, gen_status .* rmin)
+        set_upper_bound.(r, gen_status .* rmax)
     end
 
-    if !soft_thermal_limit
-        JuMP.set_upper_bound.(δf, 0)
+    # Flow and flow slack bounds
+    for e in 1:E if !branch_status[e]
+            set_upper_bound(δf[e], 0.0)
+        end
+    end
+    active_smax = branch_status .* smax
+
+    if soft_thermal_limit
+        # Soft thermal limits
+        # For active branches, sets pf + δf ≥ -smax and pf - δf ≤ smax and 0 ≤ δf ≤ Inf
+        # For inactive branches, sets pf + δf ≥ 0 and pf - δf ≤ 0 (pf = δf) and 0 ≤ δf ≤ 0 -> pf = 0
+        @constraint(model, pf_lower_bound[e in 1:E], pf[e] + δf[e] >= -active_smax[e])
+        @constraint(model, pf_upper_bound[e in 1:E], pf[e] - δf[e] <= active_smax[e])
+    else
+        # Hard thermal limits
+        # For active branches, sets pf ≥ -smax and pf ≤ smax
+        # For inactive branches, sets pf ≥ 0 and pf ≤ 0
+        @constraint(model, pf_lower_bound[e in 1:E], pf[e] >= -active_smax[e])
+        @constraint(model, pf_upper_bound[e in 1:E], pf[e] <= active_smax[e])
     end
 
-    # Constraints
+    if OPF == EconomicDispatchWithReserves
+        # Total generation
+        model[:total_generation] = Vector{ConstraintRef}(undef, G)
+        for g in 1:G if gen_status[g]
+                model[:total_generation][g] = @constraint(model, pg[g] + r[g] <= pgmax[g])
+            end
+        end
 
-    JuMP.@constraint(model,
-        total_generation[g in 1:G],
-        pg[g] + r[g] <= pmax[g]
-    )
+        @constraint(model,
+            reserve_requirement,
+            sum(r[g] for g in 1:G if gen_status[g]) >= MRR
+        )
+    end
 
-    JuMP.@constraint(model,
+    @constraint(model,
         power_balance,
-        sum(pg) + δpb_surplus - δpb_shortage == PD
+        sum(pg[g] for g in 1:G if gen_status[g]) .== PD
     )
 
-    JuMP.@constraint(model,
-        reserve_requirement,
-        sum(r) + δr_shortage >= minimum_reserve
-    )
+    model.ext[:PTDF] = LazyPTDF(data)
 
-    model.ext[:PTDF] = PM.calc_basic_ptdf_matrix(data)
-
-    model[:ptdf_flow] = Vector{JuMP.ConstraintRef}(undef, E)
+    model[:ptdf_flow] = Vector{ConstraintRef}(undef, E)
     model.ext[:tracked_branches] = zeros(Bool, E)
     model.ext[:ptdf_iterations] = 0
     
-    if !iterative_ptdf
-        (E > 1024) && @warn "EconomicDispatch: Iterative PTDF is disabled; adding all $E constraints at once. Consider using the iterative PTDF option for faster solves on large cases."
-    
-        Ag, Al, pd = _ptdf_terms_from_data(data; T=T)
+    #
+    #   III. Objective
+    #
+    l, u = extrema(c2[g] for g in 1:G if gen_status[g])
+    (l == u == 0.0) || @warn "Data $(data.case) has quadratic cost terms; those terms are being ignored"
 
-        model[:ptdf_flow] .= JuMP.@constraint(model, (model.ext[:PTDF] * Ag) * model[:pg] - model[:pf] .== model.ext[:PTDF] * (Al * pd))
-        model.ext[:tracked_branches] .= true
-        model.ext[:ptdf_iterations] = -1
+    obj_expr = if soft_thermal_limit
+        sum(c1[g] * pg[g] + c0[g] for g in 1:G if gen_status[g])
+        + thermal_penalty * sum(δf)
+    else
+        sum(c1[g] * pg[g] + c0[g] for g in 1:G if gen_status[g])
     end
 
-    # Objective
+    @objective(model, Min, obj_expr)
 
-    costs = [ref[:gen][g]["cost"] for g in 1:G]
-    l, u = extrema(costs[1] for (i, gen) in ref[:gen])
-    (l == u == 0.0) || @warn "Data $(data["name"]) has quadratic cost terms; those terms are being ignored"
-
-    JuMP.@objective(model, Min,
-        sum(costs[g][2] * pg[g] + costs[g][3] for g in 1:G) +
-        power_balance_penalty * δpb_surplus +
-        power_balance_penalty * δpb_shortage +
-        reserve_shortage_penalty * δr_shortage +
-        thermal_penalty * sum(δf)
-    )
-
-    return OPFModel{EconomicDispatch}(data, model)
+    # TODO: update to store OPFData when all formulations are done
+    return OPFModel{OPF}(network, model)
 end
 
 
-function _ptdf_terms_from_data(data::Dict{String,Any}; T=Float64)
-    N = length(data["bus"])
-    G = length(data["gen"])
-    L = length(data["load"])
-    E = length(data["branch"])
-
-    Al = sparse(
-        [data["load"]["$l"]["load_bus"] for l in 1:L],
-        [l for l in 1:L],
-        ones(T, L),
-        N,
-        L,
-    )
-
-    Ag = sparse(
-        [data["gen"]["$g"]["gen_bus"] for g in 1:G],
-        [g for g in 1:G],
-        ones(T, G),
-        N,
-        G,
-    )
-
-    pd = [data["load"]["$l"]["pd"] for l in 1:L]
-
-    return Ag, Al, pd
-end
-
-function solve!(opf::OPFModel{EconomicDispatch})
-    data = opf.data
+function solve!(opf::OPFModel{OPF}) where {OPF <: Union{EconomicDispatch, EconomicDispatchWithReserves}}
     model = opf.model
-    T = typeof(model).parameters[1]
+
+    # TODO: remove when all formulations are done
+    network = opf.data
+    data = OPFData(network)
+
+    # Grab some data
+    Ag, pd, E, smax = data.Ag, data.pd, data.E, data.smax
     tol = model.ext[:solve_metadata][:iterative_ptdf_tol]
 
-    E = length(data["branch"])
-    rate_a = [data["branch"]["$e"]["rate_a"] for e in 1:E]
+    # Get bus-wise pg VariableRef
+    pg_bus = Ag * model[:pg]
+    
+    # Compute PTDF * pd
+    ptdfb = zeros(E)
+    compute_flow!(ptdfb, pd, model.ext[:PTDF]) # ptdfb = PTDF * pd
 
-    Ag, Al, pd = _ptdf_terms_from_data(data, T=T)
-    br_pd = Al * pd
-    br_pg = Ag * model[:pg]
-    ptdfb = model.ext[:PTDF] * br_pd
+    # Initialize lazy pf buffer
+    pf_ = zeros(E)
 
+    # Initialize metadata
     solved = false
     niter = 0
     solve_time = 0.0
@@ -198,27 +177,36 @@ function solve!(opf::OPFModel{EconomicDispatch})
         :solve_time => nothing,
     )
     st = nothing
+
+    # Begin lazy PTDF loop
     solve_time = @elapsed while !solved && niter < model.ext[:solve_metadata][:max_ptdf_iterations]
+        # Solve model
         optimize!(opf.model, _differentiation_backend = MathOptSymbolicAD.DefaultBackend())
         
+        # Exit if not solved optimally
         st = termination_status(model)
         st ∈ (MOI.OPTIMAL, MOI.LOCALLY_SOLVED) || break
 
+        # Get pg and the corresponding pf_
         pg_ = value.(model[:pg])
-        p_ = Ag * pg_ - br_pd
-        pf_ = model.ext[:PTDF] * p_
-
+        p_ = Ag * pg_ - pd
+        compute_flow!(pf_, p_, model.ext[:PTDF])
+        
+        # Check pf_ for violations
         n_violated = 0
         for e in 1:E
-            if (model.ext[:tracked_branches][e]) || (-rate_a[e] - tol <= pf_[e] <= rate_a[e] + tol)
+            # Skip check if already tracked
+            if (model.ext[:tracked_branches][e]) || (-smax[e] - tol <= pf_[e] <= smax[e] + tol)
                 continue
             end
-
+            
+            # If violated, add the corresponding constraint
             n_violated += 1
             if n_violated <= model.ext[:solve_metadata][:max_ptdf_per_iteration]
-                model[:ptdf_flow][e] = JuMP.@constraint(
+                row = ptdf_row(model.ext[:PTDF], e)
+                model[:ptdf_flow][e] = @constraint(
                     model,
-                    dot(model.ext[:PTDF][e, :], br_pg) - model[:pf][e]
+                    dot(row, pg_bus) - model[:pf][e]
                     == ptdfb[e]
                 )
                 model.ext[:tracked_branches][e] = true
@@ -265,219 +253,115 @@ function solve!(opf::OPFModel{EconomicDispatch})
     model.ext[:termination_info][:ptdf_iterations] = niter
     model.ext[:termination_info][:termination_status] = st
 
+    # save the final pf based on pg
     pg_ = value.(model[:pg])
-    p_ = Ag * pg_ - br_pd
-    pf_ = model.ext[:PTDF] * p_
+    p_ = Ag * pg_ - pd
+    compute_flow!(pf_, p_, model.ext[:PTDF])
     model.ext[:ptdf_pf] = pf_
 
     return
 end
 
-function extract_result(opf::OPFModel{EconomicDispatch})
-    data = opf.data
+function extract_primal(opf::OPFModel{OPF}) where {OPF <: Union{EconomicDispatch, EconomicDispatchWithReserves}}
     model = opf.model
 
-    ref = PM.build_ref(data)[:it][:pm][:nw][0]
-    N = length(ref[:bus])
-    G = length(ref[:gen])
-    E = length(data["branch"])
+    # TODO: remove when all formulations are done
+    network = opf.data
+    data = OPFData(network)
 
-    res = Dict{String,Any}()
-    res["opf_model"] = string(model.ext[:opf_model])
-    res["objective"] = JuMP.objective_value(model)
-    res["objective_lb"] = -Inf
-    res["optimizer"] = JuMP.solver_name(model)
+    E, G = data.E, data.G
 
-    res["solve_metadata"] = model.ext[:solve_metadata]
-    if model.ext[:solve_metadata][:iterative_ptdf]
-        tinfo = model.ext[:termination_info]
-        res["termination_status"] = tinfo[:termination_status]
-        res["primal_status"] = tinfo[:primal_status]
-        res["dual_status"] = tinfo[:dual_status]
-        res["solve_time"] = tinfo[:solve_time]
-        res["ptdf_iterations"] = tinfo[:ptdf_iterations]
-    else
-        res["termination_status"] = JuMP.termination_status(model)
-        res["primal_status"] = JuMP.primal_status(model)
-        res["dual_status"] = JuMP.dual_status(model)
-        res["solve_time"] = JuMP.solve_time(model)
-    end
-    res["minimum_reserve"] = get(data, "minimum_reserve", 0.0)
-
-    res["solution"] = sol = Dict{String,Any}()
-
-    sol["per_unit"] = get(data, "per_unit", false)
-    sol["baseMVA"]  = get(data, "baseMVA", 100.0)
-
-    sol["gen"] = Dict{String,Any}()
-    for g in 1:G
-        sol["gen"]["$g"] = Dict(
-            "pg" => value(model[:pg][g]),
-            "r" => value(model[:r][g]),
-            "rmin" => get(data["gen"]["$g"], "rmin", 0.0),
-            "rmax" => get(data["gen"]["$g"], "rmax", 0.0),
-
-            "mu_pg_lb" => dual(LowerBoundRef(model[:pg][g])),
-            "mu_pg_ub" => dual(UpperBoundRef(model[:pg][g])),
-
-            "mu_r_lb" => dual(LowerBoundRef(model[:r][g])),
-            "mu_r_ub" => dual(UpperBoundRef(model[:r][g])),
-
-            "mu_total_generation" => dual(model[:total_generation][g]),
-        )
+    primal_solution = Dict{String,Any}(
+        "pg" => zeros(Float64, G),
+        "pf" => zeros(Float64, E),
+        "δf" => zeros(Float64, E),
+    )
+    
+    if OPF == EconomicDispatchWithReserves
+        primal_solution["r"] = zeros(Float64, G)
     end
 
-    sol["branch"] = Dict{String,Any}()
-    for e in 1:E
-        if data["branch"]["$e"]["br_status"] == 0
-            sol["branch"]["$e"] = Dict(
-                "pf" => 0,
-                "df" => 0,
-                "mu_pf" => 0,
-                "mu_df" => 0,
-                "lam_ptdf" => 0,
-            )
-        else
-            sol["branch"]["$e"] = Dict(
-                # "pf" => value(model[:pf][e]),
-                "pf" => model.ext[:ptdf_pf][e],
-                "df" => value(model[:δf][e]),
+    if has_values(model)
+        for g in 1:G if data.gen_status[g]
+                primal_solution["pg"][g] = value(model[:pg][g])
 
-                "mu_pf_lb" => dual(model[:pf_lower_bound][e]),
-                "mu_pf_ub" => dual(model[:pf_upper_bound][e]),
+                if OPF == EconomicDispatchWithReserves
+                    primal_solution["r"][g] = value(model[:r][g])
+                end
+            end
+        end
 
-                "mu_df_lb" => dual(LowerBoundRef(model[:δf][e])),
-
-                "lam_ptdf" => isassigned(model[:ptdf_flow], e) ? dual(model[:ptdf_flow][e]) : 0.0,
-            )
+        for e in 1:E if data.branch_status[e]
+                primal_solution["pf"][e] = value(model[:pf][e])
+                primal_solution["δf"][e] = value(model[:δf][e])
+            end
         end
     end
 
-    sol["singleton"] = Dict{String,Any}(
-        "dpb_surplus" => value(model[:δpb_surplus]),
-        "dpb_shortage" => value(model[:δpb_shortage]),
-        "dr_shortage" => value(model[:δr_shortage]),
-
-        "mu_dpb_surplus_lb" => dual(LowerBoundRef(model[:δpb_surplus])),
-        "mu_dpb_shortage_lb" => dual(LowerBoundRef(model[:δpb_shortage])),
-        "mu_dr_shortage_lb" => dual(LowerBoundRef(model[:δr_shortage])),
-
-        "mu_power_balance" => dual(model[:power_balance]),
-        "mu_reserve_requirement" => dual(model[:reserve_requirement]),
-    )
-
-    return json2h5(EconomicDispatch, res)
+    return primal_solution
 end
 
-function json2h5(::Type{EconomicDispatch}, res)
-    sol = res["solution"]
-
-    E = length(sol["branch"])
-    G = length(sol["gen"])
-
-    res_h5 = Dict{String,Any}(
-        "meta" => Dict{String,Any}(
-            "termination_status" => string(res["termination_status"]),
-            "primal_status" => string(res["primal_status"]),
-            "dual_status" => string(res["dual_status"]),
-            "solve_time" => res["solve_time"],
-            "primal_objective_value" => res["objective"],
-            "dual_objective_value" => res["objective_lb"],
-            "formulation" => string(EconomicDispatch),
-        ),
-    )
-
-    res_h5["primal"] = pres_h5 = Dict{String,Any}(
-        "pg" => zeros(Float64, G),
-        "r" => zeros(Float64, G),
-        "pf" => zeros(Float64, E),
-        "rmin" => zeros(Float64, G),
-        "rmax" => zeros(Float64, G),
-
-        "df" => zeros(Float64, E),
-        "dpb_surplus" => 0,
-        "dpb_shortage" => 0,
-        "dr_shortage" => 0,
-    )
-
-    res_h5["dual"] = dres_h5 = Dict{String,Any}(
-        "mu_pg_lb" => zeros(Float64, G),
-        "mu_pg_ub" => zeros(Float64, G),
-        "mu_r_lb" => zeros(Float64, G),
-        "mu_r_ub" => zeros(Float64, G),
-        "mu_total_generation" => zeros(Float64, G),
-        "mu_pf_lb" => zeros(Float64, E),
-        "mu_pf_ub" => zeros(Float64, E),
-        "mu_df_lb" => zeros(Float64, E),
-        "lam_ptdf" => zeros(Float64, E),
-        "mu_dpb_surplus_lb" => 0,
-        "mu_dpb_shortage_lb" => 0,
-        "mu_dr_shortage_lb" => 0,
-        "mu_power_balance" => 0,
-        "mu_reserve_requirement" => 0,
-    )
-
-    for g in 1:G
-        gsol = sol["gen"]["$g"]
-
-        pres_h5["pg"][g] = gsol["pg"]
-        pres_h5["r"][g] = gsol["r"]
-        pres_h5["rmin"][g] = gsol["rmin"]
-        pres_h5["rmax"][g] = gsol["rmax"]
-
-        dres_h5["mu_pg_lb"][g] = gsol["mu_pg_lb"]
-        dres_h5["mu_pg_ub"][g] = gsol["mu_pg_ub"]
-        dres_h5["mu_r_lb"][g] = gsol["mu_r_lb"]
-        dres_h5["mu_r_ub"][g] = gsol["mu_r_ub"]
-        dres_h5["mu_total_generation"][g] = gsol["mu_total_generation"]
-    end
-
-    for e in 1:E
-        brsol = sol["branch"]["$e"]
-
-        pres_h5["pf"][e] = brsol["pf"]
-        pres_h5["df"][e] = brsol["df"]
-
-        dres_h5["mu_pf_lb"][e] = brsol["mu_pf_lb"]
-        dres_h5["mu_pf_ub"][e] = brsol["mu_pf_ub"]
-
-        dres_h5["mu_df_lb"][e] = brsol["mu_df_lb"]
-
-        dres_h5["lam_ptdf"][e] = brsol["lam_ptdf"]
-    end
-
-    pres_h5["dpb_surplus"] = sol["singleton"]["dpb_surplus"]
-    pres_h5["dpb_shortage"] = sol["singleton"]["dpb_shortage"]
-    pres_h5["dr_shortage"] = sol["singleton"]["dr_shortage"]
-    pres_h5["minimum_reserve"] = res["minimum_reserve"]
-
-    dres_h5["mu_dpb_surplus_lb"] = sol["singleton"]["mu_dpb_surplus_lb"]
-    dres_h5["mu_dpb_shortage_lb"] = sol["singleton"]["mu_dpb_shortage_lb"]
-    dres_h5["mu_dr_shortage_lb"] = sol["singleton"]["mu_dr_shortage_lb"]
-    dres_h5["mu_power_balance"] = sol["singleton"]["mu_power_balance"]
-    dres_h5["mu_reserve_requirement"] = sol["singleton"]["mu_reserve_requirement"]
-
-    return res_h5
-
-end
-
-function export_ptdf(opf::OPFModel{EconomicDispatch}, filepath)
-    data = opf.data
+function extract_dual(opf::OPFModel{OPF}) where {OPF <: Union{EconomicDispatch, EconomicDispatchWithReserves}}
     model = opf.model
 
-    PTDF = model.ext[:PTDF]
+    # TODO: remove when all formulations are done
+    network = opf.data
+    data = OPFData(network)
 
-    h5open(filepath, "w") do file
-        write(file, "PTDF", PTDF)
+    E, G = data.E, data.G
+
+    dual_solution = Dict{String,Any}(
+        "pg_lb"               => zeros(Float64, G),
+        "pg_ub"               => zeros(Float64, G),
+        "pf_lb"               => zeros(Float64, E),
+        "pf_ub"               => zeros(Float64, E),
+        "δf_lb"               => zeros(Float64, E),
+        "δf_ub"               => zeros(Float64, E),
+        "ptdf_flow"           => zeros(Float64, E),
+        "power_balance"       => 0.0,
+    )
+
+    if OPF == EconomicDispatchWithReserves
+        dual_solution["r_lb"] = zeros(Float64, G)
+        dual_solution["r_ub"] = zeros(Float64, G)
+        dual_solution["total_generation"] = zeros(Float64, G)
+        dual_solution["reserve_requirement"] = 0.0
     end
-    return nothing
-end
 
-function export_ptdf(data::Dict{String,Any}, filepath)
-    PTDF = PM.calc_basic_ptdf_matrix(data)
+    if has_duals(model)
+        for g in 1:G if data.gen_status[g]
+                dual_solution["pg_lb"][g] = dual(LowerBoundRef(model[:pg][g]))
+                dual_solution["pg_ub"][g] = dual(UpperBoundRef(model[:pg][g]))
 
-    h5open(filepath, "w") do file
-        write(file, "PTDF", PTDF)
+                if OPF == EconomicDispatchWithReserves
+                    dual_solution["r_lb"][g] = dual(LowerBoundRef(model[:r][g]))
+                    dual_solution["r_ub"][g] = dual(UpperBoundRef(model[:r][g]))
+                    dual_solution["total_generation"][g] = dual(model[:total_generation][g])
+                end
+            end
+        end
+
+        for e in 1:E if data.branch_status[e]
+                dual_solution["pf_lb"][e] = dual(model[:pf_lower_bound][e])
+                dual_solution["pf_ub"][e] = dual(model[:pf_upper_bound][e])
+                dual_solution["δf_lb"][e] = dual(LowerBoundRef(model[:δf][e]))
+
+                if has_upper_bound(model[:δf][e])
+                    dual_solution["δf_ub"][e] = dual(UpperBoundRef(model[:δf][e]))
+                end
+
+                if isassigned(model[:ptdf_flow], e)
+                    dual_solution["ptdf_flow"][e] = dual(model[:ptdf_flow][e])
+                end
+            end
+        end
+
+        dual_solution["power_balance"] = dual(model[:power_balance])
+        
+        if OPF == EconomicDispatchWithReserves
+            dual_solution["reserve_requirement"] = dual(model[:reserve_requirement])
+        end
     end
-    return nothing
+
+    return dual_solution
 end

--- a/src/opf/ed.jl
+++ b/src/opf/ed.jl
@@ -90,12 +90,12 @@ function build_opf(::Type{EconomicDispatch}, network::Dict{String,Any}, optimize
     # Total reserve requirement
     @constraint(model,
         global_reserve_requirement,
-        sum(r[g] for g in 1:G if gen_status[g]) >= MRR
+        sum(gen_status[g] * r[g] for g in 1:G) >= MRR
     )
 
     @constraint(model,
         global_power_balance,
-        sum(pg[g] for g in 1:G if gen_status[g]) == PD
+        sum(gen_status[g] * pg[g] for g in 1:G) == PD
     )
 
     model.ext[:PTDF] = LazyPTDF(data)

--- a/src/opf/ed.jl
+++ b/src/opf/ed.jl
@@ -262,7 +262,7 @@ function extract_primal(opf::OPFModel{EconomicDispatch})
 
         for e in 1:E 
             data.branch_status[e] || continue
-            primal_solution["pf"][e] = value(model[:pf][e])
+            primal_solution["pf"][e] = value(model.ext[:ptdf_pf][e])
             primal_solution["δf"][e] = value(model[:δf][e])
         end
     end

--- a/src/opf/ed.jl
+++ b/src/opf/ed.jl
@@ -228,11 +228,13 @@ function solve!(opf::OPFModel{EconomicDispatch})
     model.ext[:termination_info][:ptdf_iterations] = niter
     model.ext[:termination_info][:termination_status] = st
 
-    # save the final pf based on pg
-    pg_ = value.(model[:pg])
-    p_ = Ag * pg_ - pd
-    compute_flow!(pf_, p_, model.ext[:PTDF])
-    model.ext[:ptdf_pf] = pf_
+    if has_values(model)
+        # save the final pf based on pg
+        pg_ = value.(model[:pg])
+        p_ = Ag * pg_ - pd
+        compute_flow!(pf_, p_, model.ext[:PTDF])
+        model.ext[:ptdf_pf] = pf_
+    end
 
     return
 end

--- a/src/opf/opf.jl
+++ b/src/opf/opf.jl
@@ -301,7 +301,6 @@ const SUPPORTED_OPF_MODELS = Type{<:AbstractFormulation}[
     ACOPF,
     DCOPF,
     EconomicDispatch,
-    EconomicDispatchWithReserves,
     SOCOPFQuad,
     SOCOPF,
 ]
@@ -312,7 +311,6 @@ const OPF2TYPE = Dict{String,Type{<:AbstractFormulation}}(
     "ACOPF" => ACOPF,
     "DCOPF" => DCOPF,
     "EconomicDispatch" => EconomicDispatch,
-    "EconomicDispatchWithReserves" => EconomicDispatchWithReserves,
     "SOCOPFQuad" => SOCOPFQuad,
     "SOCOPF" => SOCOPF,
 )

--- a/src/opf/opf.jl
+++ b/src/opf/opf.jl
@@ -301,6 +301,7 @@ const SUPPORTED_OPF_MODELS = Type{<:AbstractFormulation}[
     ACOPF,
     DCOPF,
     EconomicDispatch,
+    EconomicDispatchWithReserves,
     SOCOPFQuad,
     SOCOPF,
 ]
@@ -311,6 +312,7 @@ const OPF2TYPE = Dict{String,Type{<:AbstractFormulation}}(
     "ACOPF" => ACOPF,
     "DCOPF" => DCOPF,
     "EconomicDispatch" => EconomicDispatch,
+    "EconomicDispatchWithReserves" => EconomicDispatchWithReserves,
     "SOCOPFQuad" => SOCOPFQuad,
     "SOCOPF" => SOCOPF,
 )

--- a/test/io.jl
+++ b/test/io.jl
@@ -148,33 +148,12 @@ function test_json_io()
     return nothing
 end
 
-function test_export_ptdf()
-    data = make_basic_network(pglib("14_ieee"))
-    solver = OPT_SOLVERS[OPFGenerator.EconomicDispatch]
-    opf = OPFGenerator.build_opf(OPFGenerator.EconomicDispatch, data, solver)
-    
-    f5 = tempname()
-    OPFGenerator.export_ptdf(opf, f5)
-
-    h = HDF5.h5read(f5, "/")
-    @test haskey(h, "PTDF")
-    @test h["PTDF"] == opf.model.ext[:PTDF]
-
-    f51 = tempname()
-    OPFGenerator.export_ptdf(data, f51)
-
-    h1 = HDF5.h5read(f51, "/")
-    @test haskey(h1, "PTDF")
-    @test h1["PTDF"] == h["PTDF"]
-end
-
 @testset "I/O" begin
     @testset "HDF5" begin
         @testset test_h5_supported_types()
         @testset test_h5_precision_warning()
         @testset test_h5_invalid_types()
         @testset test_h5_io()
-        @testset test_export_ptdf()
     end
     @testset "JSON" begin
         @testset test_json_io()

--- a/test/opf/ed.jl
+++ b/test/opf/ed.jl
@@ -11,9 +11,9 @@ function test_opf_pm(::Type{OPF}, data::Dict) where {OPF <: Union{OPFGenerator.E
     res = OPFGenerator.extract_result(opf)
 
     # Solve OPF with PowerModels
-    # must be after OPFGenerator since it modifies `data`
+    data_pm = deepcopy(data)
     solver = OPT_SOLVERS[OPF]
-    res_pm = PM.solve_opf_ptdf_branch_power_cuts!(data, solver)
+    res_pm = PM.solve_opf_ptdf_branch_power_cuts!(data_pm, solver)
 
     # Check that the right problem was indeed solved
     @test res["meta"]["formulation"] == string(OPF)

--- a/test/opf/opf.jl
+++ b/test/opf/opf.jl
@@ -17,7 +17,11 @@ function test_opf_pm(OPF::Type{<:OPFGenerator.AbstractFormulation}, casename::St
     drop_gen = argmin(gen->gen[2]["pmax"], network_drop["gen"])[1]
     network_drop["gen"][drop_gen]["gen_status"] = 0
 
-    @testset "Branch/Gen Status" begin test_opf_pm(OPF, network_drop) end
+    if OPF ∉ [OPFGenerator.EconomicDispatch, OPFGenerator.EconomicDispatchWithReserves]
+        @testset "Branch/Gen Status" begin test_opf_pm(OPF, network_drop) end
+    else
+        @test_throws ErrorException test_opf_pm(OPF, network_drop) # ED does not yet support branch status
+    end
 end
 
 """

--- a/test/opf/opf.jl
+++ b/test/opf/opf.jl
@@ -17,10 +17,10 @@ function test_opf_pm(OPF::Type{<:OPFGenerator.AbstractFormulation}, casename::St
     drop_gen = argmin(gen->gen[2]["pmax"], network_drop["gen"])[1]
     network_drop["gen"][drop_gen]["gen_status"] = 0
 
-    if OPF ∉ [OPFGenerator.EconomicDispatch, OPFGenerator.EconomicDispatchWithReserves]
-        @testset "Branch/Gen Status" begin test_opf_pm(OPF, network_drop) end
-    else
+    if OPF == OPFGenerator.EconomicDispatch
         @test_throws ErrorException test_opf_pm(OPF, network_drop) # ED does not yet support branch status
+    else
+        @testset "Branch/Gen Status" begin test_opf_pm(OPF, network_drop) end
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,8 +27,8 @@ const OPT_SOLVERS = Dict(
     OPFGenerator.SOCOPF            => CLRBL_SOLVER,
     OPFGenerator.DCOPF             => CLRBL_SOLVER,
     OPFGenerator.EconomicDispatch  => CLRBL_SOLVER,
-    OPFGenerator.EconomicDispatchWithReserves => CLRBL_SOLVER,
 )
+
 
 include("io.jl")
 include("bridges.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,6 +27,7 @@ const OPT_SOLVERS = Dict(
     OPFGenerator.SOCOPF            => CLRBL_SOLVER,
     OPFGenerator.DCOPF             => CLRBL_SOLVER,
     OPFGenerator.EconomicDispatch  => CLRBL_SOLVER,
+    OPFGenerator.EconomicDispatchWithReserves => CLRBL_SOLVER,
 )
 
 include("io.jl")

--- a/test/sampler.jl
+++ b/test/sampler.jl
@@ -342,12 +342,6 @@ function test_sampler_script()
                     "name" => "Clarabel",
                 )
             ),
-            "EDR" => Dict(
-                "type" => "EconomicDispatchWithReserves",
-                "solver" => Dict(
-                    "name" => "Clarabel",
-                )
-            ),
             "SOCOPF" => Dict(
                 "type" => "SOCOPF",
                 "solver" => Dict(

--- a/test/sampler.jl
+++ b/test/sampler.jl
@@ -342,11 +342,8 @@ function test_sampler_script()
                     "name" => "Clarabel",
                 )
             ),
-            "ED_noniterative" => Dict(
-                "type" => "EconomicDispatch",
-                "kwargs" => Dict(
-                    "iterative_ptdf" => false,
-                ),
+            "EDR" => Dict(
+                "type" => "EconomicDispatchWithReserves",
                 "solver" => Dict(
                     "name" => "Clarabel",
                 )


### PR DESCRIPTION
This PR updates the EconomicDispatch implementation:

- Add reserve bounds + MRR to OPFData
- Separate types for ED/EDR
- No soft power balance or soft reserve requirement option
- Remove `export_ptdf`

Todo:
- [x] add a `has_values` check before grabbing `pg` in `solve!`
- [x] extract `ptdf_pf`, not `pf`
- [x] set constraint coefficients to zero for reserve requirement, power balance
- [ ] if `vector-formulations` switches to load-wise `pd` before this is merged, update `solve!` to account