### PR TITLE
Load-level information

### DIFF
--- a/src/opf/acp.jl
+++ b/src/opf/acp.jl
@@ -89,7 +89,7 @@ function build_opf(::Type{ACOPF}, network::Dict{String,Any}, optimizer;
         - sum(branch_status[e] * pt[e] for e in bus_arcs_to[i])
         - gs[i] * vm[i]^2
         == 
-        pd[i]
+        sum(pd[l] for l in data.bus_loads[i])
     )
     @constraint(model,
         kcl_q[i in 1:N],
@@ -98,7 +98,7 @@ function build_opf(::Type{ACOPF}, network::Dict{String,Any}, optimizer;
         - sum(branch_status[e] * qt[e] for e in bus_arcs_to[i])
         + bs[i] * vm[i]^2
         ==
-        qd[i]
+        sum(qd[l] for l in data.bus_loads[i])
     )
 
 

--- a/src/opf/dcp.jl
+++ b/src/opf/dcp.jl
@@ -64,7 +64,7 @@ function build_opf(::Type{DCOPF}, network::Dict{String,Any}, optimizer;
         - sum(branch_status[a] * pf[a] for a in bus_arcs_fr[i])
         - sum(branch_status[a] * pt[a] for a in bus_arcs_to[i])  # pt == -pf
         == 
-        pd[i] + gs[i]
+        sum(pd[l] for l in data.bus_loads[i]) + gs[i]
     )
 
     @constraint(model, 

--- a/src/opf/opf.jl
+++ b/src/opf/opf.jl
@@ -26,12 +26,15 @@ struct OPFData
     vmax::Vector{Float64}
     gs::Vector{Float64}  # shunt
     bs::Vector{Float64}  # shunt
-    pd::Vector{Float64}  # nodal active power load
-    qd::Vector{Float64}  # nodal reactive power load
     bus_arcs_fr::Vector{Vector{Int}}  # indices of branches exiting the bus
     bus_arcs_to::Vector{Vector{Int}}  # indices of branches entering the bus
     bus_gens::Vector{Vector{Int}}  # indices of generators at the bus
+    bus_loads::Vector{Vector{Int}}
     ref_bus::Int  # index of slack bus
+
+    # Load data
+    pd::Vector{Float64}  # active power demand
+    qd::Vector{Float64}  # reactive power demand
 
     # Generator data
     pgmin::Vector{Float64}
@@ -97,20 +100,23 @@ function OPFData(network::Dict{String,Any})
         bs[i] += shunt["bs"]
     end
 
-    # Aggregate loads at the bus level
-    pd = zeros(Float64, N)
-    qd = zeros(Float64, N)
-    for (_, load) in network["load"]
-        load["status"] == 1 || continue  # skip inactive loads
-        i = load["load_bus"]
-        pd[i] += load["pd"]
-        qd[i] += load["qd"]
-    end
-
     # Reference bus
     ref_buses = [i for i in 1:N if network["bus"]["$i"]["bus_type"] == 3]
     @assert length(ref_buses) == 1 "There must be exactly one reference bus"
     ref_bus = ref_buses[1]
+
+    # Load data
+    pd = zeros(Float64, L)
+    qd = zeros(Float64, L)
+    bus_loads = [Int[] for _ in 1:N]
+    for l in 1:L
+        load = network["load"]["$l"]
+        i = load["load_bus"]
+        push!(bus_loads[i], l)
+        pd[l] = (load["status"] == 1) * load["pd"]
+        qd[l] = (load["status"] == 1) * load["qd"]
+    end
+    sort!.(bus_loads)
 
     # Generator data
     pgmin = zeros(Float64, G)
@@ -142,7 +148,7 @@ function OPFData(network::Dict{String,Any})
         c1[g] = gen["cost"][2]
         c2[g] = gen["cost"][1]
 
-        gen_status[g] = gen["gen_status"] == 1
+        gen_status[g] = (gen["gen_status"] == 1)
 
         # Generator incidence matrix
         Ag_i[g] = gen["gen_bus"]
@@ -255,8 +261,9 @@ function OPFData(network::Dict{String,Any})
     return OPFData(
         network["name"], network["baseMVA"],
         N, E, G, L, A, Ag,
-        vnom, vmin, vmax, gs, bs, pd, qd,
-        bus_arcs_fr, bus_arcs_to, bus_gens, ref_bus,
+        vnom, vmin, vmax, gs, bs,
+        bus_arcs_fr, bus_arcs_to, bus_gens, bus_loads, ref_bus,
+        pd, qd,
         pgmin, pgmax,
         qgmin, qgmax,
         c0, c1, c2,

--- a/src/opf/socwr.jl
+++ b/src/opf/socwr.jl
@@ -102,7 +102,7 @@ function build_opf(::Type{OPF}, network::Dict{String,Any}, optimizer;
         - sum(branch_status[e] * pt[e] for e in bus_arcs_to[i])
         - gs[i] * w[i]
         == 
-        pd[i]
+        sum(pd[l] for l in data.bus_loads[i])
     )
     @constraint(model,
         kcl_q[i in 1:N],
@@ -111,7 +111,7 @@ function build_opf(::Type{OPF}, network::Dict{String,Any}, optimizer;
         - sum(branch_status[e] * qt[e] for e in bus_arcs_to[i])
         + bs[i] * w[i]
         ==
-        qd[i]
+        sum(qd[l] for l in data.bus_loads[i])
     )
 
     # Branch power flow physics and limit constraints

--- a/test/opf/opf.jl
+++ b/test/opf/opf.jl
@@ -49,8 +49,6 @@ include("ed.jl")
 # other tests
 include("quad_obj.jl")
 
-const PGLIB_CASES = ["14_ieee", "30_ieee", "57_ieee", "89_pegase", "118_ieee"]
-
 @testset "OPF" begin
     @testset "$(OPF)" for OPF in OPFGenerator.SUPPORTED_OPF_MODELS
         @testset "$(casename)" for casename in PGLIB_CASES
@@ -65,7 +63,6 @@ const PGLIB_CASES = ["14_ieee", "30_ieee", "57_ieee", "89_pegase", "118_ieee"]
 
     @testset _test_socwr_DualFeasibility()
 end
-
 
 @testset "OPFData" begin
     test_voltage_phasor_bounds_scalar()

--- a/test/opf/utils.jl
+++ b/test/opf/utils.jl
@@ -4,6 +4,7 @@ function test_opfdata(data::OPFGenerator.OPFData, network::Dict{String,Any})
     @test data.N == length(network["bus"])
     @test data.E == length(network["branch"])
     @test data.G == length(network["gen"])
+    @test data.L == length(network["load"])
 
     # Bus data
     @test data.vmin == [ref[:bus][i]["vmin"] for i in 1:data.N]
@@ -21,13 +22,8 @@ function test_opfdata(data::OPFGenerator.OPFData, network::Dict{String,Any})
     @test data.gs == gs_ref
 
     # Aggregate loads at the bus level
-    pd_ref = zeros(Float64, data.N)
-    qd_ref = zeros(Float64, data.N)
-
-    for (_, load) in ref[:load]  # filters out inactive loads
-        pd_ref[load["load_bus"]] += load["pd"]
-        qd_ref[load["load_bus"]] += load["qd"]
-    end
+    pd_ref = [network["load"]["$l"]["pd"] for l in 1:L]
+    qd_ref = [network["load"]["$l"]["qd"] for l in 1:L]
 
     @test data.pd == pd_ref
     @test data.qd == qd_ref

--- a/test/opf/utils.jl
+++ b/test/opf/utils.jl
@@ -22,8 +22,8 @@ function test_opfdata(data::OPFGenerator.OPFData, network::Dict{String,Any})
     @test data.gs == gs_ref
 
     # Aggregate loads at the bus level
-    pd_ref = [network["load"]["$l"]["pd"] for l in 1:L]
-    qd_ref = [network["load"]["$l"]["qd"] for l in 1:L]
+    pd_ref = [network["load"]["$l"]["pd"] for l in 1:data.L]
+    qd_ref = [network["load"]["$l"]["qd"] for l in 1:data.L]
 
     @test data.pd == pd_ref
     @test data.qd == qd_ref

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,8 +30,5 @@ const OPT_SOLVERS = Dict(
 )
 
 
-include("io.jl")
-include("bridges.jl")
-include("sampler.jl")
-include("opf/opf.jl")
-include("postprocess.jl")
+const PGLIB_CASES = ["14_ieee", "30_ieee", "57_ieee", "89_pegase", "118_ieee"]
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,3 +32,8 @@ const OPT_SOLVERS = Dict(
 
 const PGLIB_CASES = ["14_ieee", "30_ieee", "57_ieee", "89_pegase", "118_ieee"]
 
+include("io.jl")
+include("bridges.jl")
+include("sampler.jl")
+include("opf/opf.jl")
+include("postprocess.jl")


### PR DESCRIPTION
Current state only changes the `OPFData` struct and parsers. 
Still need to update
* [x] ACOPF (https://github.com/AI4OPT/OPFGenerator/pull/128/commits/f6dfdc27def7bd020ac7a88bbcb052285d6834db)
* [x] SOCOPF (https://github.com/AI4OPT/OPFGenerator/pull/128/commits/d861573312c9fc312725e604286fb3aecbd52514)
* [x] DCOPF (https://github.com/AI4OPT/OPFGenerator/pull/128/commits/47e7cfeac8c0309699e8fdf152127680477018b4)
* [x] EconomicDispatch (https://github.com/AI4OPT/OPFGenerator/pull/128/commits/d45aea7a0f985ac6b0d83deec4d961ec699ef563)
    [EDIT]: the ED branch will need to update the `solve!` code, which currently uses bus-level demand data. 