### PR TITLE
Update SLURM pipeline

### DIFF
--- a/exp/config.toml
+++ b/exp/config.toml
@@ -1,15 +1,15 @@
 # Name of the reference PGLib case. Must be a valid PGLib case name.
-ref = "pglib_opf_case300_ieee"
+ref = "89_pegase"
 # Directory where instance/solution files are exported
 # must be a valid directory
-export_dir = "data/300_ieee"
+export_dir = "data/89_pegase"
 
 [sampler]
 # Sampler options
 [sampler.load]
-noise_type = "ScaledLogNormal"  # Only "ScaledLogNormal" is supported at the moment
-l          = 0.8                # Lower bound of base load factor
-u          = 1.05               # Upper bound of base load factor
+noise_type = "ScaledUniform"
+l          = 0.60               # Lower bound of base load factor
+u          = 1.00               # Upper bound of base load factor
 sigma      = 0.15               # Relative (multiplicative) noise level.
 
 [sampler.reserve]
@@ -27,7 +27,7 @@ type = "Full"
 [OPF.DCOPF]
 # Formulation/solver options
 type = "DCOPF"
-solver.name = "Mosek"
+solver.name = "HiGHS"
 
 [OPF.ACOPF]
 type = "ACOPF"
@@ -35,19 +35,27 @@ solver.name = "Ipopt"
 solver.attributes.tol = 1e-6
 solver.attributes.linear_solver = "ma27"
 
-[OPF.ED]
+[OPF.EDSoftThermal]
 type = "EconomicDispatch"
 kwargs.soft_thermal_limit = true
-solver.name = "Mosek"
+solver.name = "HiGHS"
 
 [OPF.SOCOPF]
 type = "SOCOPF"
-solver.name = "Mosek"
-# Loosened tolerances improve Mosek's convergence
-solver.attributes.MSK_DPAR_INTPNT_CO_TOL_PFEAS = 1e-6
-solver.attributes.MSK_DPAR_INTPNT_CO_TOL_DFEAS = 1e-6
-solver.attributes.MSK_DPAR_INTPNT_CO_TOL_MU_RED = 1e-6
-solver.attributes.MSK_DPAR_INTPNT_CO_TOL_REL_GAP = 1e-6
+solver.name = "Clarabel"
+# Tight tolerances
+solver.attributes.tol_gap_abs    = 1e-6
+solver.attributes.tol_gap_rel    = 1e-6
+solver.attributes.tol_feas       = 1e-6
+solver.attributes.tol_infeas_rel = 1e-6
+solver.attributes.tol_ktratio    = 1e-6
+# Reduced accuracy settings
+solver.attributes.reduced_tol_gap_abs    = 1e-6
+solver.attributes.reduced_tol_gap_rel    = 1e-6
+solver.attributes.reduced_tol_feas       = 1e-6
+solver.attributes.reduced_tol_infeas_abs = 1e-6
+solver.attributes.reduced_tol_infeas_rel = 1e-6
+solver.attributes.reduced_tol_ktratio    = 1e-6
 
 [OPF.SOCOPF128]
 # These settings are meant to solve `SOCWRConic` problems to high precision

--- a/exp/sampler.jl
+++ b/exp/sampler.jl
@@ -72,7 +72,7 @@ end
 
 function main(data, config)
     d = Dict{String,Any}()
-    d["meta"] = deepcopy(config)
+    d["config"] = deepcopy(config)
     
     # Keep track of input data
     d["data"] = data

--- a/exp/sampler.jl
+++ b/exp/sampler.jl
@@ -134,7 +134,7 @@ if abspath(PROGRAM_FILE) == @__FILE__
         rng = StableRNG(s)
         tgen = @elapsed data_ = rand(rng, opf_sampler)
         tsolve = @elapsed res = main(data_, config)
-        res["meta"]["seed"] = s
+        res["config"]["seed"] = s
 
         # Update input data
         push!(D["input"]["meta"]["seed"], s)

--- a/slurm/merge.jl
+++ b/slurm/merge.jl
@@ -48,6 +48,10 @@ function main(config::Dict)
 
     rm(joinpath(export_dir, "res_h5"), recursive=true)
 
+    if "--no-split" in ARGS || get(slurm_config, "no_split", false)
+        return
+    end
+
     rng = MersenneTwister(42)
 
     feasible = nothing

--- a/slurm/merge.jl
+++ b/slurm/merge.jl
@@ -12,7 +12,7 @@ function main(config::Dict)
     casename = config["ref"]
     all_h5_files = filter(endswith(".h5"), readdir(joinpath(export_dir, "res_h5"), join=true))
 
-    pop!(config, "slurm")
+    slurm_config = pop!(config, "slurm")
     config_str = JSON.json(config)
 
     # Process each dataset
@@ -74,7 +74,7 @@ function main(config::Dict)
 
     shuffle!(rng, feasible_idx)
 
-    n_train = Int(floor(0.8 * n_feasible))
+    n_train = Int(floor(get(slurm_config, "train_ratio", 0.8) * n_feasible))
     train_idx = sort(feasible_idx[1:n_train])
     test_idx = sort(feasible_idx[n_train+1:end])
 

--- a/slurm/merge.jl
+++ b/slurm/merge.jl
@@ -3,13 +3,16 @@ using HDF5
 using JSON
 using TOML
 using Base.Threads
+using Random
 
 main(fconfig::AbstractString) = main(TOML.parsefile(fconfig))
 
 function main(config::Dict)
-    export_dir = config["export_dir"]
+    export_dir = pop!(config, "export_dir")
     casename = config["ref"]
     all_h5_files = filter(endswith(".h5"), readdir(joinpath(export_dir, "res_h5"), join=true))
+
+    pop!(config, "slurm")
     config_str = JSON.json(config)
 
     # Process each dataset
@@ -30,12 +33,94 @@ function main(config::Dict)
         # Save dataset to disk
         get!(D, "meta", Dict{String,Any}())
         D["meta"]["config"] = config_str
-        OPFGenerator.save_h5(joinpath(export_dir, "$(casename)_$(dataset_name).h5"), D);
+
+        if dataset_name == "input"
+            OPFGenerator.save_h5(joinpath(export_dir, "input.h5"), D)
+        else
+            mkpath(joinpath(export_dir, dataset_name))
+            OPFGenerator.save_h5(joinpath(export_dir, dataset_name, "meta.h5"), D["meta"])
+            OPFGenerator.save_h5(joinpath(export_dir, dataset_name, "primal.h5"), D["primal"])
+            OPFGenerator.save_h5(joinpath(export_dir, dataset_name, "dual.h5"), D["dual"])
+        end
 
         GC.gc()
     end
 
-    return nothing    
+    rm(joinpath(export_dir, "res_h5"), recursive=true)
+
+    rng = MersenneTwister(42)
+
+    feasible = nothing
+    n_samples = nothing
+
+    # find inputs that are feasible for all OPFs
+    for opf in OPFs
+        h5open(joinpath(export_dir, opf, "meta.h5"), "r") do f
+            if isnothing(feasible)
+                n_samples = length(read(f["termination_status"]))
+                feasible = trues(n_samples)
+            end
+            feasible .&= (String.(read(f["termination_status"])) .== "OPTIMAL") .| (String.(read(f["termination_status"])) .== "LOCALLY_SOLVED")
+            feasible .&= (String.(read(f["primal_status"])) .== "FEASIBLE_POINT")
+            feasible .&= (String.(read(f["dual_status"])) .== "FEASIBLE_POINT")
+        end
+    end
+
+    n_feasible = sum(feasible)
+    @info "Number of feasible samples: $n_feasible / $n_samples"
+
+    feasible_idx = findall(feasible)
+    infeasible_idx = sort(findall(.!feasible))
+
+    shuffle!(rng, feasible_idx)
+
+    n_train = Int(floor(0.8 * n_feasible))
+    train_idx = sort(feasible_idx[1:n_train])
+    test_idx = sort(feasible_idx[n_train+1:end])
+
+    @info "Number of train samples: $(length(train_idx))"
+    @info "Number of test samples: $(length(test_idx))"
+
+    mkpath(joinpath(export_dir, "train"))
+    mkpath(joinpath(export_dir, "test"))
+    mkpath(joinpath(export_dir, "infeasible"))
+
+    for opf in OPFs
+        for file in ["primal", "dual", "meta"]
+            h5open(joinpath(export_dir, opf, "$file.h5"), "r") do f
+                for (idx, split) in zip([train_idx, test_idx, infeasible_idx], ["train", "test", "infeasible"])
+                    mkpath(joinpath(export_dir, split, opf))
+                    h5open(joinpath(export_dir, split, opf, "$file.h5"), "w") do g
+                        for k in keys(f)
+                            val = read(f[k])
+                            g[k] = if k != "config" collect(selectdim(val, ndims(val), idx)) else val end
+                        end
+                    end
+                end
+            end
+            rm(joinpath(export_dir, opf, "$file.h5"))
+        end
+        rm(joinpath(export_dir, opf))
+    end
+    # same for input
+    h5open(joinpath(export_dir, "input.h5"), "r") do f
+        for (idx, split) in zip([train_idx, test_idx, infeasible_idx], ["train", "test", "infeasible"])
+            h5open(joinpath(export_dir, split, "input.h5"), "w") do g
+                create_group(g, "data")
+                for k in keys(f["data"])
+                    val = read(f["data"][k])
+                    g["data"][k] = collect(selectdim(val, ndims(val), idx))
+                end
+
+                create_group(g, "meta")
+                for k in keys(f["meta"])
+                    val = read(f["meta"][k])
+                    g["meta"][k] = if k != "config" collect(selectdim(val, ndims(val), idx)) else val end
+                end
+            end
+        end
+    end
+    rm(joinpath(export_dir, "input.h5"))
 end
 
 if abspath(PROGRAM_FILE) == @__FILE__

--- a/slurm/merge.jl
+++ b/slurm/merge.jl
@@ -64,9 +64,9 @@ function main(config::Dict)
                 n_samples = length(read(f["termination_status"]))
                 feasible = trues(n_samples)
             end
-            feasible .&= (String.(read(f["termination_status"])) .== "OPTIMAL") .| (String.(read(f["termination_status"])) .== "LOCALLY_SOLVED")
-            feasible .&= (String.(read(f["primal_status"])) .== "FEASIBLE_POINT")
-            feasible .&= (String.(read(f["dual_status"])) .== "FEASIBLE_POINT")
+            feasible .&= (read(f["termination_status"]) .== "OPTIMAL") .| (read(f["termination_status"]) .== "LOCALLY_SOLVED")
+            feasible .&= (read(f["primal_status"]) .== "FEASIBLE_POINT")
+            feasible .&= (read(f["dual_status"]) .== "FEASIBLE_POINT")
         end
     end
 

--- a/slurm/submit_jobs.jl
+++ b/slurm/submit_jobs.jl
@@ -43,7 +43,8 @@ mkpath(logs_dir)
 @info "Generating $S samples"
 B, r = divrem(S, J)
 B = B + (r > 0)
-for (j, seed_range) in enumerate(partition(1:S, B))
+jobs = partition(1:S, B)
+for (j, seed_range) in enumerate(jobs)
     # Update job files
     open(joinpath(jobs_dir, "jobs_$j.txt"), "w") do io
         for minibatch in partition(seed_range, b)
@@ -110,7 +111,7 @@ sampler_sbatch = Mustache.render(
         logs_dir=logs_dir,
         jobs_dir=jobs_dir,
         queue=queue,
-        J=J,
+        J=length(jobs),
         opfgenerator_dir=opfgenerator_dir,
         sampler_memory=sampler_memory,
         cpus_per_task=cpus_per_task,

--- a/slurm/submit_jobs.jl
+++ b/slurm/submit_jobs.jl
@@ -26,36 +26,24 @@ cpus_per_task = get(config["slurm"], "cpus_per_task", 24)
 env_path = get(config["slurm"], "env_path", joinpath(@__DIR__, "template", "env.sh"))
 sampler_script = get(config["slurm"], "sampler_script", joinpath(opfgenerator_dir, "exp", "sampler.jl"))
 
-B, r = divrem(S, J)
-B = B + (r > 0)
-
 datasetname = splitdir(result_dir)[end]
 
 slurm_dir = joinpath(result_dir, "slurm")
-json_dir = joinpath(result_dir, "res_json")
 h5_dir = joinpath(result_dir, "res_h5")
-
 jobs_dir = joinpath(slurm_dir, "jobs")
 logs_dir = joinpath(slurm_dir, "logs")
 
 mkpath(result_dir)
-mkpath(json_dir)
 mkpath(h5_dir)
 mkpath(slurm_dir)
 mkpath(jobs_dir)
 mkpath(logs_dir)
 
 # identify all missing jobs
-h = falses(S)
-@threads for s in 1:S
-    h[s] = isfile(joinpath(json_dir, "$(case)_s$(s).json.gz"))
-end
-@info "Missing $(S - sum(h)) instances"
-missing_seeds = (1:S)[.!h]
-S_ = length(missing_seeds)
-B, r = divrem(S_, J)
+@info "Generating $S samples"
+B, r = divrem(S, J)
 B = B + (r > 0)
-for (j, seed_range) in enumerate(partition(missing_seeds, B))
+for (j, seed_range) in enumerate(partition(1:S, B))
     # Update job files
     open(joinpath(jobs_dir, "jobs_$j.txt"), "w") do io
         for minibatch in partition(seed_range, b)


### PR DESCRIPTION
- [x] Produce datasets like #109 by default. There is also a `no_split` option to just make one dataset.
- [x] Use vectorized data structure
- [x] Don't save slurm settings in dataset files
- [x] Update example `exp/config.toml` file