### PR TITLE
Compress final output files

### DIFF
--- a/slurm/make_ref.jl
+++ b/slurm/make_ref.jl
@@ -18,4 +18,4 @@ include("../exp/sampler.jl")
 d = main(data, config)
 
 mkpath(export_dir)
-OPFGenerator.save_json("$(export_dir)/case.json", d)
+OPFGenerator.save_json("$(export_dir)/case.json.gz", d)

--- a/slurm/merge.jl
+++ b/slurm/merge.jl
@@ -89,6 +89,8 @@ function main(config::Dict)
     mkpath(joinpath(export_dir, "test"))
     mkpath(joinpath(export_dir, "infeasible"))
 
+    compression_level = get(slurm_config, "compression_level", 9)
+
     for opf in OPFs
         for file in ["primal", "dual", "meta"]
             h5open(joinpath(export_dir, opf, "$file.h5"), "r") do f
@@ -97,7 +99,7 @@ function main(config::Dict)
                     h5open(joinpath(export_dir, split, opf, "$file.h5"), "w") do g
                         for k in keys(f)
                             val = read(f[k])
-                            g[k] = if k != "config" collect(selectdim(val, ndims(val), idx)) else val end
+                            g[k, compress=compression_level] = if k != "config" collect(selectdim(val, ndims(val), idx)) else val end
                         end
                     end
                 end
@@ -113,13 +115,13 @@ function main(config::Dict)
                 create_group(g, "data")
                 for k in keys(f["data"])
                     val = read(f["data"][k])
-                    g["data"][k] = collect(selectdim(val, ndims(val), idx))
+                    g["data"][k, compress=compression_level] = collect(selectdim(val, ndims(val), idx))
                 end
 
                 create_group(g, "meta")
                 for k in keys(f["meta"])
                     val = read(f["meta"][k])
-                    g["meta"][k] = if k != "config" collect(selectdim(val, ndims(val), idx)) else val end
+                    g["meta"][k, compress=compression_level] = if k != "config" collect(selectdim(val, ndims(val), idx)) else val end
                 end
             end
         end


### PR DESCRIPTION
- [x] Uses the [deflate/zlib integration](https://juliaio.github.io/HDF5.jl/stable/#Chunking-and-compression) in HDF5.jl to compress the datasets in the final output files. The highest compression level is enabled by default.
- [x] Uses gzip compression via `OPFGenerator.save_json` by default for the reference `case.json.gz` file.  
- [ ] Run some benchmarks with various compression options