### PR TITLE
Provide case file in config 

### DIFF
--- a/exp/config.toml
+++ b/exp/config.toml
@@ -1,5 +1,5 @@
 # Name of the reference PGLib case. Must be a valid PGLib case name.
-ref = "89_pegase"
+pglib_case = "89_pegase"
 # Directory where instance/solution files are exported
 # must be a valid directory
 export_dir = "data/89_pegase"

--- a/exp/sampler.jl
+++ b/exp/sampler.jl
@@ -97,8 +97,7 @@ if abspath(PROGRAM_FILE) == @__FILE__
     main(data0, config)
 
     # Load reference data and setup OPF sampler
-    case_name = get(config, "case_name", "case")
-    case_file = config["case_file"]
+    case_file, case_name = OPFGenerator._get_case_info(config)
     isfile(case_file) || error("Reference case file not found: $(case_file)")
     data = OPFGenerator.OPFData(make_basic_network(PowerModels.parse_file(case_file)))
     opf_sampler = OPFGenerator.SimpleOPFSampler(data, config["sampler"])

--- a/exp/sampler.jl
+++ b/exp/sampler.jl
@@ -97,6 +97,7 @@ if abspath(PROGRAM_FILE) == @__FILE__
     main(data0, config)
 
     # Load reference data and setup OPF sampler
+    case_name = get(config, "case_name", "case")
     case_file = config["case_file"]
     isfile(case_file) || error("Reference case file not found: $(case_file)")
     data = OPFGenerator.OPFData(make_basic_network(PowerModels.parse_file(case_file)))
@@ -106,7 +107,6 @@ if abspath(PROGRAM_FILE) == @__FILE__
     N, E, L, G = data.N, data.E, data.L, data.G
 
     OPFs = sort(collect(keys(config["OPF"])))
-    case_name = data.case == "" ? "case" : data.case
     
     # Place-holder for results. 
     # For each OPF configutation, we keep a Vector of individual h5 outputs

--- a/exp/sampler.jl
+++ b/exp/sampler.jl
@@ -97,14 +97,16 @@ if abspath(PROGRAM_FILE) == @__FILE__
     main(data0, config)
 
     # Load reference data and setup OPF sampler
-    data = OPFGenerator.OPFData(make_basic_network(pglib(config["ref"])))
+    case_file = config["case_file"]
+    isfile(case_file) || error("Reference case file not found: $(case_file)")
+    data = OPFGenerator.OPFData(make_basic_network(PowerModels.parse_file(case_file)))
     opf_sampler = OPFGenerator.SimpleOPFSampler(data, config["sampler"])
 
     # Data info
     N, E, L, G = data.N, data.E, data.L, data.G
 
     OPFs = sort(collect(keys(config["OPF"])))
-    caseref = config["ref"]
+    case_name = data.case == "" ? "case" : data.case
     
     # Place-holder for results. 
     # For each OPF configutation, we keep a Vector of individual h5 outputs
@@ -134,7 +136,7 @@ if abspath(PROGRAM_FILE) == @__FILE__
     end
 
     # Data generation
-    @info "Generating instances for case $caseref\nSeed range: [$smin, $smax]\nDatasets: $OPFs"
+    @info "Generating instances for case $(case_name)\nSeed range: [$smin, $smax]\nDatasets: $OPFs"
     for s in smin:smax
         rng = MersenneTwister(s)
         tgen = @elapsed data_ = rand(rng, opf_sampler)
@@ -182,7 +184,7 @@ if abspath(PROGRAM_FILE) == @__FILE__
 
     # Save to disk in separate h5 files
     for (k, v) in D
-        filepath = joinpath(config["export_dir"], "res_h5", "$(caseref)_$(k)_s$(smin)-s$(smax).h5")
+        filepath = joinpath(config["export_dir"], "res_h5", "$(case_name)_$(k)_s$(smin)-s$(smax).h5")
         mkpath(dirname(filepath))
         th5write = @elapsed OPFGenerator.save_h5(filepath, v)
     end

--- a/slurm/make_ref.jl
+++ b/slurm/make_ref.jl
@@ -7,11 +7,11 @@ using OPFGenerator
 
 config_file = ARGS[1]
 config = TOML.parsefile(config_file)
-case_file = config["case_file"]
+case_file, case_name = OPFGenerator._get_case_info(config)
 export_dir = pop!(config, "export_dir")
 pop!(config, "slurm")
 
-data = OPFGenerator.OPFData(make_basic_network(PowerModels.parse_file(config["case_file"])))
+data = OPFGenerator.OPFData(make_basic_network(PowerModels.parse_file(case_file)))
 
 include("../exp/sampler.jl")
 

--- a/slurm/make_ref.jl
+++ b/slurm/make_ref.jl
@@ -7,11 +7,11 @@ using OPFGenerator
 
 config_file = ARGS[1]
 config = TOML.parsefile(config_file)
-casename = config["ref"]
+case_file = config["case_file"]
 export_dir = pop!(config, "export_dir")
 pop!(config, "slurm")
 
-data = OPFGenerator.OPFData(make_basic_network(pglib(casename)))
+data = OPFGenerator.OPFData(make_basic_network(PowerModels.parse_file(config["case_file"])))
 
 include("../exp/sampler.jl")
 

--- a/slurm/merge.jl
+++ b/slurm/merge.jl
@@ -9,7 +9,7 @@ main(fconfig::AbstractString) = main(TOML.parsefile(fconfig))
 
 function main(config::Dict)
     export_dir = pop!(config, "export_dir")
-    casename = config["ref"]
+    case_name = config["case_name"]
     all_h5_files = filter(endswith(".h5"), readdir(joinpath(export_dir, "res_h5"), join=true))
 
     slurm_config = pop!(config, "slurm")
@@ -18,7 +18,7 @@ function main(config::Dict)
     # Process each dataset
     OPFs = sort(collect(keys(config["OPF"])))
     for dataset_name in ["input"; OPFs]
-        rgx = Regex("$(casename)_$(dataset_name)_s\\d+-s\\d+.h5")
+        rgx = Regex("$(case_name)_$(dataset_name)_s\\d+-s\\d+.h5")
         res_files = filter(s -> startswith(basename(s), rgx), all_h5_files)
         nfiles = length(res_files)
         Ds = Vector{Dict{String,Any}}(undef, nfiles)

--- a/slurm/merge.jl
+++ b/slurm/merge.jl
@@ -9,7 +9,7 @@ main(fconfig::AbstractString) = main(TOML.parsefile(fconfig))
 
 function main(config::Dict)
     export_dir = pop!(config, "export_dir")
-    case_name = config["case_name"]
+    case_file, case_name = OPFGenerator._get_case_info(config)
     all_h5_files = filter(endswith(".h5"), readdir(joinpath(export_dir, "res_h5"), join=true))
 
     slurm_config = pop!(config, "slurm")

--- a/slurm/submit_jobs.jl
+++ b/slurm/submit_jobs.jl
@@ -9,7 +9,8 @@ config = TOML.parsefile(config_file)
 
 opfgenerator_dir = "$(@__DIR__)/../"
 
-case = config["ref"]
+case_file = config["case_file"]
+case_name = config["case_name"]
 result_dir = config["export_dir"]
 S = config["slurm"]["n_samples"]
 J = config["slurm"]["n_jobs"]
@@ -49,7 +50,7 @@ for (j, seed_range) in enumerate(jobs)
     open(joinpath(jobs_dir, "jobs_$j.txt"), "w") do io
         for minibatch in partition(seed_range, b)
             smin, smax = extrema(minibatch)
-            println(io, "$(julia_bin) --project=. -t1 $(sampler_script) $(config_file) $(smin) $(smax) > $(logs_dir)/$(case)_$(smin)-$(smax).log 2>&1")
+            println(io, "$(julia_bin) --project=. -t1 $(sampler_script) $(config_file) $(smin) $(smax) > $(logs_dir)/$(case_name)_$(smin)-$(smax).log 2>&1")
         end
     end
 end

--- a/slurm/submit_jobs.jl
+++ b/slurm/submit_jobs.jl
@@ -1,16 +1,19 @@
 using Base.Iterators
 using Base.Threads
 using Mustache
+using Pkg
 using TOML
+
+using OPFGenerator
 
 
 config_file = ARGS[1]
 config = TOML.parsefile(config_file)
 
-opfgenerator_dir = "$(@__DIR__)/../"
+opfgenerator_dir = normpath(joinpath(dirname(pathof(OPFGenerator)), ".."))
 
-case_file = config["case_file"]
-case_name = config["case_name"]
+case_file, case_name = OPFGenerator._get_case_info(config)
+isfile(case_file) || error("Reference case file not found: $(case_file)")
 result_dir = config["export_dir"]
 S = config["slurm"]["n_samples"]
 J = config["slurm"]["n_jobs"]

--- a/src/OPFGenerator.jl
+++ b/src/OPFGenerator.jl
@@ -17,6 +17,7 @@ export ScaledLogNormal, ScaledUniform
 
 include("utils/json.jl")
 include("utils/hdf5.jl")
+include("config.jl")
 
 # OPF formulations
 include("opf/opf.jl")

--- a/src/config.jl
+++ b/src/config.jl
@@ -32,7 +32,7 @@ function _get_case_info(config)
         error("Invalid config: must provide either \"case_file\" or \"pglib_case\".")
     end
 
-    case_name = if haskey(config, "case_name")
+    case_name = if get(config, "case_name", "") != ""
         config["case_name"]
     else
         splitext(basename(case_file))[1]

--- a/src/config.jl
+++ b/src/config.jl
@@ -32,10 +32,8 @@ function _get_case_info(config)
         error("Invalid config: must provide either \"case_file\" or \"pglib_case\".")
     end
 
-    case_name = if get(config, "case_name", "") != ""
-        config["case_name"]
-    else
-        splitext(basename(case_file))[1]
-    end
+    case_name = splitext(basename(case_file))[1]
+    case_name == "" && (case_name = "case")  # generic fallback, just in case
+
     return case_file, case_name
 end

--- a/src/config.jl
+++ b/src/config.jl
@@ -38,7 +38,7 @@ function _get_case_info(config)
         # Use PGLib case name only if no case file was provided
         config["pglib_case"]
     else
-        "case"
+        splitext(basename(case_file))[1]
     end
     return case_file, case_name
 end

--- a/src/config.jl
+++ b/src/config.jl
@@ -1,0 +1,44 @@
+"""
+    _get_case_info(config)
+
+Extract case file and name from input `config`.
+
+To be valid, the input config should include:
+* either a `case_file` or `pglib_case` entry
+* if no `case_file` is provided, `pglib_case` should be a valid, unique PGLib case name.
+
+The case name will be set to the generic \"case\" value if none is provided.
+
+!!! warning
+    if `case_file` is provided, `pglib_case` will be ignored.
+    Therefore, users should provide `case_name` when supplying `case_file`.
+"""
+function _get_case_info(config)
+    case_file = if haskey(config, "case_file")
+        config["case_file"]
+    elseif haskey(config, "pglib_case")
+        # Check that case reference is valid PGLib name
+        pglib_cases = PGLib.find_pglib_case(config["pglib_case"])
+        if length(pglib_cases) == 1
+            # All good
+            joinpath(PGLib.PGLib_opf, pglib_cases[1])
+        elseif length(pglib_cases) == 0
+            error("PGLib case `$(case_name)` was not found. Try running `PGLib.find_pglib_case(\"$(case_name)\")` to find similar case names.")
+        else
+            error("""PGLib case returned matches; please update the case name to be more specific.
+            Matching PGLib cases:\n""" * prod("* $(case)\n" for case in pglib_cases))
+        end
+    else
+        error("Invalid config: must provide either \"case_file\" or \"pglib_case\".")
+    end
+
+    case_name = if haskey(config, "case_name")
+        config["case_name"]
+    elseif haskey(config, "pglib_case") && !haskey(config, "case_file")
+        # Use PGLib case name only if no case file was provided
+        config["pglib_case"]
+    else
+        "case"
+    end
+    return case_file, case_name
+end

--- a/src/config.jl
+++ b/src/config.jl
@@ -34,9 +34,6 @@ function _get_case_info(config)
 
     case_name = if haskey(config, "case_name")
         config["case_name"]
-    elseif haskey(config, "pglib_case") && !haskey(config, "case_file")
-        # Use PGLib case name only if no case file was provided
-        config["pglib_case"]
     else
         splitext(basename(case_file))[1]
     end

--- a/test/sampler.jl
+++ b/test/sampler.jl
@@ -199,7 +199,7 @@ function test_sampler_script()
     sampler_script = joinpath(@__DIR__, "..", "exp", "sampler.jl")
     temp_dir = mktempdir()
     config = Dict(
-        "ref" => "pglib_opf_case14_ieee",
+        "pglib_case" => "pglib_opf_case14_ieee",
         "export_dir" => temp_dir,
         "sampler" => Dict(
             "load" => Dict(

--- a/test/sampler.jl
+++ b/test/sampler.jl
@@ -279,7 +279,7 @@ function test_sampler_script()
         TOML.print(io, config)
     end
 
-    caseref = config["ref"]
+    case_file, case_name = OPFGenerator._get_case_info(config)
     smin, smax = 1, 4
     proc = run(setenv(`$(joinpath(Sys.BINDIR, "julia")) --project=. $sampler_script $config_file $smin $smax`, dir=joinpath(@__DIR__, "..")))
 
@@ -291,7 +291,7 @@ function test_sampler_script()
 
     @test isdir(h5_dir)
 
-    input_file_path = joinpath(h5_dir, "$(caseref)_input_s$smin-s$smax.h5")
+    input_file_path = joinpath(h5_dir, "$(case_name)_input_s$smin-s$smax.h5")
     @test isfile(input_file_path)
     # Check that input data file is structured as expected
     h5open(input_file_path, "r") do h5
@@ -323,7 +323,7 @@ function test_sampler_script()
     end
 
     h5_paths = [
-        joinpath(h5_dir, "$(caseref)_$(opf)_s$smin-s$smax.h5")
+        joinpath(h5_dir, "$(case_name)_$(opf)_s$smin-s$smax.h5")
         for opf in OPFs
     ]
     @test all(isfile.(h5_paths))


### PR DESCRIPTION
This (draft) PR modifies the structure of the config file and data-generation scripts to support datasets beyond PGLib cases.
**The core feature I want is the ability to generate data given an arbitrary, user-provided Matpower file.** (see #131)

The current code uses a `"ref"` key in the config file to load the corresponding PGLib case using the `PGLib` package.
This prevents us from generating data based on anything that's not PGLib.

This branch replaces the config key `ref` with _two_ keys:
* `case_file`: path to Matpower case; data-generation will error if path is not valid.
* `case_name`: this effectively replaces the `"ref"` we had before

The reason for adding `case_name` is that we currently use `config["ref"]` not only to load data, but also in file naming conventions and for some logging messages. It could be replaced with `data.case`, but...
1. we are not guaranteed that `data.case` won't be empty
2. it requires accessing the `OPFData` struct, which is OK in `exp/sampler.jl`, but not OK in `slurm/submit_jobs.jl` because of this line
  https://github.com/AI4OPT/OPFGenerator/blob/c5093dbc551b7a73f2d87e4daefc7ca7256ffdfc/slurm/submit_jobs.jl#L52
  where `case` is defined earlier as `config["ref"]` (and the data file is never loaded).

