### PR TITLE
Add `GlocalPQ`

### DIFF
--- a/src/sampler/glocalpq.jl
+++ b/src/sampler/glocalpq.jl
@@ -1,0 +1,61 @@
+"""
+    GlocalPQ{G,L}
+
+A glocal distribution with global/local factors `α::G` separate active/reactive factors `η₁::L` and `η₂::L`.
+
+This distribution represents a random variable of the form `ϵ = α×η`, where
+* `α` is a _scalar_ random variable, with distribution `d_α::G`
+* `η₁` is a _vector_ random variable, with distribution `d_η::L`
+* `η₂` is a _vector_ random variable, with distribution `d_η::L`
+* `α`, `η₁`, and `η₂` are independent random variables
+"""
+struct GlocalPQ{G<:UvDist,L<:MvDist} <: MvDist
+    d_α::G
+    d_η::L
+end
+
+function GlocalPQ(d::Glocal)
+    return GlocalPQ(d.d_α, d.d_η)
+end
+
+Distributions.length(d::GlocalPQ) = length(d.d_η)
+Distributions.eltype(::GlocalPQ) = Float64
+
+function Distributions._rand!(::AbstractRNG, ::GlocalPQ, ::AbstractArray)
+    throw(DimensionMismatch(
+        "Inconsistent argument dimensions: only vector and matrix-shaped `x` is supported."
+    ))
+end
+
+function Distributions._rand!(rng::AbstractRNG, d::GlocalPQ, x::AbstractVector)
+    length(x) == length(d) || throw(DimensionMismatch("Inconsistent argument dimensions."))
+
+    x₁ = x
+    x₂ = similar(x₁)
+
+    α = rand(rng, d.d_α)
+    η₁ = rand(rng, d.d_η)
+    η₂ = rand(rng, d.d_η)
+
+    x₁ .= α .* η₁
+    x₂ .= α .* η₂
+
+    return x₁, x₂
+end
+
+function Distributions._rand!(rng::AbstractRNG, d::GlocalPQ, x::AbstractMatrix)
+    size(x, 1) == length(d) || throw(DimensionMismatch("Inconsistent argument dimensions."))
+    n = size(x, 2)
+
+    x₁ = x
+    x₂ = similar(x₁)
+
+    α = rand(rng, d.d_α, n)
+    η₁ = rand(rng, d.d_η, n)
+    η₂ = rand(rng, d.d_η, n)
+
+    mul!(x₁, η₁, Diagonal(α))  # re-scales every column `η[:, j]` by `α[j]`
+    mul!(x₂, η₂, Diagonal(α))
+
+    return x₁, x₂
+end

--- a/src/sampler/load.jl
+++ b/src/sampler/load.jl
@@ -42,7 +42,7 @@ function LoadScaler(data::OPFData, options::Dict)
     # Noise distribution
     # TODO: modularize this
     noise_type = get(options, "noise_type", "")
-    if noise_type ∉ ["ScaledLogNormal", "ScaledUniform"]
+    if noise_type ∉ ["ScaledLogNormal", "ScaledUniform", "ScaledLogNormalPQ", "ScaledUniformPQ"]
         error("""Invalid noise type for load: $(noise_type). Supported values are:
         * \"ScaledLogNormal\"
         * \"ScaledUniform\"""")
@@ -77,6 +77,10 @@ function LoadScaler(data::OPFData, options::Dict)
         ScaledLogNormal(l, u, σs)
     elseif noise_type == "ScaledUniform"
         ScaledUniform(l, u, σs)
+    elseif noise_type == "ScaledLogNormalPQ"
+        GlocalPQ(ScaledLogNormal(l, u, σs))
+    elseif noise_type == "ScaledUniformPQ"
+        GlocalPQ(ScaledUniform(l, u, σs))
     end
 
     return LoadScaler(d, pd, qd)

--- a/src/sampler/load.jl
+++ b/src/sampler/load.jl
@@ -16,11 +16,20 @@ struct LoadScaler{D} <: AbstractLoadSampler
     qd_ref::Vector{Float64}
 end
 
-function Random.rand(rng::AbstractRNG, ls::LoadScaler)
+function Random.rand(rng::AbstractRNG, ls::LoadScaler{T}) where T <: Glocal
     ϵ = rand(rng, ls.d)  # sample multiplicative noise
 
     pd = ϵ .* ls.pd_ref
     qd = ϵ .* ls.qd_ref
+
+    return pd, qd
+end
+
+function Random.rand(rng::AbstractRNG, ls::LoadScaler{T}) where T <: GlocalPQ
+    ϵ₁, ϵ₂ = rand(rng, ls.d)
+
+    pd = ϵ₁ .* ls.pd_ref
+    qd = ϵ₂ .* ls.qd_ref
 
     return pd, qd
 end

--- a/src/sampler/sampler.jl
+++ b/src/sampler/sampler.jl
@@ -1,5 +1,6 @@
 # common distributions
 include("glocal.jl")
+include("glocalpq.jl")
 
 abstract type AbstractOPFSampler end
 

--- a/test/sampler.jl
+++ b/test/sampler.jl
@@ -38,6 +38,7 @@ function test_ScaledLogNormal()
     d = ScaledLogNormal(0.8, 1.2, 0.05 .* ones(3))
 
     @test length(d) == 3
+    @test eltype(d) == Float64
 
     @test isa(d, OPFGenerator.Glocal)
     @test d.d_α == Uniform(0.8, 1.2)
@@ -54,6 +55,7 @@ function test_ScaledUniform()
     d = ScaledUniform(0.8, 1.2, 0.05 .* ones(5))
 
     @test length(d) == 5
+    @test eltype(d) == Float64
 
     @test isa(d, OPFGenerator.Glocal)
     @test d.d_α == Uniform(0.8, 1.2)
@@ -70,6 +72,7 @@ function test_ScaledLogNormalPQ()
     d = OPFGenerator.GlocalPQ(ScaledLogNormal(0.8, 1.2, 0.05 .* ones(3)))
 
     @test length(d) == 3
+    @test eltype(d) == Float64
 
     @test isa(d, OPFGenerator.GlocalPQ)
     @test d.d_α == Uniform(0.8, 1.2)
@@ -86,6 +89,7 @@ function test_ScaledUniformPQ()
     d = OPFGenerator.GlocalPQ(ScaledUniform(0.8, 1.2, 0.05 .* ones(5)))
 
     @test length(d) == 5
+    @test eltype(d) == Float64
 
     @test isa(d, OPFGenerator.GlocalPQ)
     @test d.d_α == Uniform(0.8, 1.2)
@@ -203,17 +207,20 @@ function test_sampler()
         )
     )
     
-    opf_sampler  = SimpleOPFSampler(data, sampler_config)
-    data1 = rand(MersenneTwister(42), opf_sampler)
+    for noise_type in ["ScaledLogNormal", "ScaledUniformPQ"]
+        sampler_config["load"]["noise_type"] = noise_type
+        
+        opf_sampler  = SimpleOPFSampler(data, sampler_config)
+        data1 = rand(MersenneTwister(42), opf_sampler)
 
-    # No side-effect checks
-    @test data == _data   # initial data should not have been modified
-    @test data !== data1  # new data should be a different dictionary
+        # No side-effect checks
+        @test data == _data   # initial data should not have been modified
+        @test data !== data1  # new data should be a different dictionary
 
-    # Same RNG and seed should give the same data
-    data2 = rand(MersenneTwister(42), opf_sampler)
-    @test data2 == data1
-
+        # Same RNG and seed should give the same data
+        data2 = rand(MersenneTwister(42), opf_sampler)
+        @test data2 == data1
+    end
     return nothing
 end
 


### PR DESCRIPTION
`GlocalPQ` is like `Glocal` but with independent (and identically distributed) local noise for the active/reactive load demands. This is implemented by sampling from `d_η` twice: https://github.com/AI4OPT/OPFGenerator/blob/c06dc07c480206957e4f0dcd52646336fd9245dd/src/sampler/glocalpq.jl#L37-L41 instead of once: https://github.com/AI4OPT/OPFGenerator/blob/c06dc07c480206957e4f0dcd52646336fd9245dd/src/sampler/glocal.jl#L32-L34