### PR TITLE
Add safeguards for querying primal/dual objective value

### DIFF
--- a/src/opf/utils.jl
+++ b/src/opf/utils.jl
@@ -65,14 +65,34 @@ end
 function extract_metadata(opf::OPFModel{<:AbstractFormulation})
     model = opf.model
 
+    tst = termination_status(model)
+    pst = primal_status(model)
+    dst = dual_status(model)
+
+    # Query primal/dual objective value only if 
+    # * a primal/dual solution exists
+    # * it's a point (i.e. not a ray, not a reduction certificate)
+    OK_STATUSES = [MOI.FEASIBLE_POINT, MOI.NEARLY_FEASIBLE_POINT, MOI.INFEASIBLE_POINT]
+
+    z_primal = if has_values(model) && pst ∈ OK_STATUSES
+        objective_value(model)
+    else
+        NaN
+    end
+    z_dual = if has_duals(model) && dst ∈ OK_STATUSES
+        dual_objective_value(model) 
+    else
+        NaN
+    end
+
     return Dict{String,Any}(
         "formulation" => string(model.ext[:opf_model]),
-        "termination_status" => string(termination_status(model)),
-        "primal_status" => string(primal_status(model)),
-        "dual_status" => string(dual_status(model)),
+        "termination_status" => string(tst),
+        "primal_status" => string(pst),
+        "dual_status" => string(dst),
         "solve_time" => solve_time(model),
-        "primal_objective_value" => if has_values(model) objective_value(model) else Inf end,
-        "dual_objective_value" => if has_duals(model) dual_objective_value(model) else -Inf end,
+        "primal_objective_value" => z_primal,
+        "dual_objective_value" => z_dual,
     )
 end
 

--- a/src/opf/utils.jl
+++ b/src/opf/utils.jl
@@ -79,7 +79,7 @@ function extract_metadata(opf::OPFModel{<:AbstractFormulation})
     else
         NaN
     end
-    z_dual = if has_duals(model) && dst ∈ OK_STATUSES
+    z_dual = if dst ∈ OK_STATUSES
         dual_objective_value(model) 
     else
         NaN

--- a/src/opf/utils.jl
+++ b/src/opf/utils.jl
@@ -74,7 +74,7 @@ function extract_metadata(opf::OPFModel{<:AbstractFormulation})
     # * it's a point (i.e. not a ray, not a reduction certificate)
     OK_STATUSES = [MOI.FEASIBLE_POINT, MOI.NEARLY_FEASIBLE_POINT, MOI.INFEASIBLE_POINT]
 
-    z_primal = if has_values(model) && pst ∈ OK_STATUSES
+    z_primal = if pst ∈ OK_STATUSES
         objective_value(model)
     else
         NaN


### PR DESCRIPTION
Fixes #146

Small change to how we report primal/dual objective values.

Before: we check `has_values` and `has_duals`, and return `objective_value` and `dual_objective_value` accordingly. If a model doesn't have a primal/dual solution, we report `Inf` (primal) and `-Inf` (dual).

After: in addition to checking `has_values` and `has_duals`, we check whether the solution status is either `FEASIBLE_POINT`, `NEARLY_FEASIBLE_POINT`, or `INFEASIBLE_POINT`. If both conditions are met, then we return `objective_value` and `dual_objective_value` accordingly. Otherwise, we return a `NaN` value.

A couple notes: 
* primal/dual are checked separately, i.e., there may be a primal objective value but no dual objective value
* there is no change to the export of the primal/dual solution itself: if a solution is available, we export it; users need to check the solution status before using solution values.