### PR TITLE
Update AC/DC docs

### DIFF
--- a/docs/definitions.jl
+++ b/docs/definitions.jl
@@ -1,0 +1,29 @@
+""" 
+    convert_latex_to_mathjax(s::String)
+
+Converts a string of LaTeX to a pair, e.g. \\newcommand{\\RR}{\\mathbb{R}} to :RR => "\\mathbb{R}".
+"""
+function convert_newcommand_to_pair(s::AbstractString)
+    if startswith(s, "\\newcommand{\\")
+        parts = split(s, "}{")
+        @assert length(parts) == 2
+        cmd = replace(parts[1], "\\newcommand{\\" => "")
+        return Symbol(cmd) => parts[2][1:end-1]
+    end
+
+    return nothing
+end
+
+"""
+    make_macros_dict(definitions_path::AbstractString)
+
+Create a `Documenter.HTMLWriter.MathJax3` `config` based on a LaTeX file containing `\\newcomand` definitions.
+"""
+function make_macros_dict(definitions_path::AbstractString)
+    defs_txt = read(definitions_path, String)
+    pairs = filter(
+        !isnothing,
+        map(convert_newcommand_to_pair ∘ strip, split(defs_txt, "\n"))
+    )
+    return Dict(pairs)
+end

--- a/docs/definitions.jl
+++ b/docs/definitions.jl
@@ -1,5 +1,5 @@
 """ 
-    convert_latex_to_mathjax(s::String)
+    convert_newcommand_to_pair(s::AbstractString)
 
 Converts a string of LaTeX to a pair, e.g. \\newcommand{\\RR}{\\mathbb{R}} to :RR => "\\mathbb{R}".
 """

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,6 +8,7 @@ makedocs(
     modules=[OPFGenerator],
     sitename = "OPFGenerator",
     format = Documenter.HTML(;
+        assets = ["assets/wider.css"],
         mathengine = Documenter.MathJax3(Dict(
             :tex => Dict(
                 "macros" => make_macros_dict("docs/src/assets/definitions.tex"),

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,11 +1,20 @@
 using Documenter
 using OPFGenerator
 
+
+include("definitions.jl")
+
 makedocs(
     modules=[OPFGenerator],
     sitename = "OPFGenerator",
     format = Documenter.HTML(;
-        mathengine = Documenter.MathJax(),
+        mathengine = Documenter.MathJax3(Dict(
+            :tex => Dict(
+                "macros" => make_macros_dict("docs/src/assets/definitions.tex"),
+                "inlineMath" => [["\$","\$"], ["\\(","\\)"]],
+                "tags" => "ams",
+            ),
+        )),
     ),
     pages = [
         "Home" => "index.md",

--- a/docs/src/assets/definitions.tex
+++ b/docs/src/assets/definitions.tex
@@ -13,13 +13,13 @@
 
 % OPF parameters
 % lower/upper bounds on active/reactive generation
-\newcommand{\pgmin}{\underline{\text{p}}^{\text{g}}}
-\newcommand{\pgmax}{\overline{\text{p}}^{\text{g}}}
-\newcommand{\qgmin}{\underline{\text{q}}^{\text{g}}}
-\newcommand{\qgmax}{\overline{\text{q}}^{\text{g}}}
+\newcommand{\pgmin}{\underline{{p}}^{\text{g}}}
+\newcommand{\pgmax}{\overline{{p}}^{\text{g}}}
+\newcommand{\qgmin}{\underline{{q}}^{\text{g}}}
+\newcommand{\qgmax}{\overline{{q}}^{\text{g}}}
 % Lower / upper bounds on voltage magnitude
-\newcommand{\vmmin}{\underline{\text{v}}}
-\newcommand{\vmmax}{\overline{\text{v}}}
+\newcommand{\vmmin}{\underline{{v}}}
+\newcommand{\vmmax}{\overline{{v}}}
 % Lower/upper bounds on angle deviation
 \newcommand{\dvamin}{\underline{\Delta} \theta}
 \newcommand{\dvamax}{\overline{\Delta} \theta}
@@ -56,9 +56,9 @@
 % complex demand
 \newcommand{\SD}{S^{\text{d}}}
 % active load
-\newcommand{\PD}{\mathbf{p}^{\text{d}}}
+\newcommand{\PD}{{p}^{\text{d}}}
 % reactive load
-\newcommand{\QD}{\mathbf{q}^{\text{d}}}
+\newcommand{\QD}{{q}^{\text{d}}}
 % active shunt
 \newcommand{\GS}{{g}^{\text{s}}}
 % reactive shunt

--- a/docs/src/assets/definitions.tex
+++ b/docs/src/assets/definitions.tex
@@ -13,10 +13,10 @@
 
 % OPF parameters
 % lower/upper bounds on active/reactive generation
-\newcommand{\pgmin}{\underline{\mathbf{p}}^{\text{g}}}
-\newcommand{\pgmax}{\overline{\mathbf{p}}^{\text{g}}}
-\newcommand{\qgmin}{\underline{\mathbf{q}}^{\text{g}}}
-\newcommand{\qgmax}{\overline{\mathbf{q}}^{\text{g}}}
+\newcommand{\pgmin}{\underline{\text{p}}^{\text{g}}}
+\newcommand{\pgmax}{\overline{\text{p}}^{\text{g}}}
+\newcommand{\qgmin}{\underline{\text{q}}^{\text{g}}}
+\newcommand{\qgmax}{\overline{\text{q}}^{\text{g}}}
 % Lower / upper bounds on voltage magnitude
 \newcommand{\vmmin}{\underline{\text{v}}}
 \newcommand{\vmmax}{\overline{\text{v}}}

--- a/docs/src/assets/definitions.tex
+++ b/docs/src/assets/definitions.tex
@@ -1,0 +1,157 @@
+% Imaginary unit
+\newcommand{\im}{\mathbf{j}}
+
+% Branch admittance parameters
+\newcommand{\gff}{g^{\text{ff}}}
+\newcommand{\gft}{g^{\text{ft}}}
+\newcommand{\gtf}{g^{\text{tf}}}
+\newcommand{\gtt}{g^{\text{tt}}}
+\newcommand{\bff}{b^{\text{ff}}}
+\newcommand{\bft}{b^{\text{ft}}}
+\newcommand{\btf}{b^{\text{tf}}}
+\newcommand{\btt}{b^{\text{tt}}}
+
+% OPF parameters
+% lower/upper bounds on active/reactive generation
+\newcommand{\pgmin}{\underline{\mathbf{p}}^{\text{g}}}
+\newcommand{\pgmax}{\overline{\mathbf{p}}^{\text{g}}}
+\newcommand{\qgmin}{\underline{\mathbf{q}}^{\text{g}}}
+\newcommand{\qgmax}{\overline{\mathbf{q}}^{\text{g}}}
+% Lower / upper bounds on voltage magnitude
+\newcommand{\vmmin}{\underline{\text{v}}}
+\newcommand{\vmmax}{\overline{\text{v}}}
+% Lower/upper bounds on angle deviation
+\newcommand{\dvamin}{\underline{\Delta} \theta}
+\newcommand{\dvamax}{\overline{\Delta} \theta}
+
+% w variables (for SOC formulation)
+% SOC variables (and bounds)
+\newcommand{\wm}{\mathbf{w}}
+\newcommand{\wmin}{\underline{\mathbf{w}}}
+\newcommand{\wmax}{\overline{\mathbf{w}}}
+\renewcommand{\wr}{\mathbf{w}^{\text{re}}}
+\newcommand{\wi}{\mathbf{w}^{\text{im}}}
+\newcommand{\wrmin}{\underline{\mathbf{w}}^{\text{re}}}
+\newcommand{\wrmax}{\overline{\mathbf{w}}^{\text{re}}}
+\newcommand{\wimin}{\underline{\mathbf{w}}^{\text{im}}}
+\newcommand{\wimax}{\overline{\mathbf{w}}^{\text{im}}}
+
+% acopf
+% Power System
+\newcommand{\PS}{\mathcal{P}} 
+% edges (lines + transformers)
+\newcommand{\EDGES}{\mathcal{E}}
+\newcommand{\BRANCHES}{\EDGES}
+\newcommand{\LOADS}{\mathcal{L}}
+\newcommand{\GENERATORS}{\mathcal{G}}
+\newcommand{\NODES}{\mathcal{N}}
+% complex generation
+\newcommand{\SG}{S^{\text{g}}}
+% active power generation
+\newcommand{\PG}{\mathbf{p}^{\text{g}}}
+% active power reserve
+\newcommand{\PR}{\mathbf{p}^{\text{r}}}
+% reactive power generation
+\newcommand{\QG}{\mathbf{q}^{\text{g}}}
+% complex demand
+\newcommand{\SD}{S^{\text{d}}}
+% active load
+\newcommand{\PD}{\mathbf{p}^{\text{d}}}
+% reactive load
+\newcommand{\QD}{\mathbf{q}^{\text{d}}}
+% active shunt
+\newcommand{\GS}{{g}^{\text{s}}}
+% reactive shunt
+\newcommand{\BS}{{b}^{\text{s}}}
+% complex voltage
+\newcommand{\V}{\mathbf{V}} 
+% voltage magnitude
+\newcommand{\VM}{\mathbf{v}}
+% voltage angle
+\newcommand{\VA}{\boldsymbol{\theta}}
+% difference in voltage angle
+\newcommand{\DVA}{\Delta\boldsymbol{\theta}}
+% complex flow
+\newcommand{\SF}{S^{\text{f}}}
+% active flow
+\newcommand{\PF}{\mathbf{p}^{\text{f}}} 
+% reactive flow
+\newcommand{\QF}{\mathbf{q}^{\text{f}}} 
+% active flow
+\newcommand{\PT}{\mathbf{p}^{\text{t}}} 
+% reactive flow
+\newcommand{\QT}{\mathbf{q}^{\text{t}}} 
+% dual multipliers
+\newcommand{\LMDA}{\boldsymbol{\lambda}}
+% dual multipliers
+\newcommand{\MU}{\boldsymbol{\mu}}
+% penalty coefficients
+\newcommand{\RHO}{\boldsymbol{\rho}}
+
+
+%% Dual variables
+% Notation convention:
+%   * \lambda --> equality constraints
+%   * \mu     --> linear inequality constraints
+%   * \nu     --> conic (SOC) constraints
+% Power balance (active/reactive)
+\newcommand{\lambdaP}{\lambda^{\text{p}}}
+\newcommand{\lambdaQ}{\lambda^{\text{q}}}
+% Ohm's law (active/reactive, from/to)
+\newcommand{\lambdaf}{{\lambda}^{\text{f}}}
+\newcommand{\lambdat}{{\lambda}^{\text{t}}}
+\newcommand{\lambdaPf}{{\lambda}^{\text{pf}}}
+\newcommand{\lambdaPt}{{\lambda}^{\text{pt}}}
+\newcommand{\lambdaQf}{{\lambda}^{\text{qf}}}
+\newcommand{\lambdaQt}{{\lambda}^{\text{qt}}}
+
+% Transmission limit (from/to)
+\newcommand{\nuThermalfr}{{\nu}^{\text{f}}}
+\newcommand{\nuThermalSfr}{{\nu}^{\text{sf}}}
+\newcommand{\nuThermalPfr}{{\nu}^{\text{pf}}}
+\newcommand{\nuThermalQfr}{{\nu}^{\text{qf}}}
+\newcommand{\nuThermalto}{{\nu}^{\text{t}}}
+\newcommand{\nuThermalSto}{{\nu}^{\text{st}}}
+\newcommand{\nuThermalPto}{{\nu}^{\text{pt}}}
+\newcommand{\nuThermalQto}{{\nu}^{\text{qt}}}
+
+% Voltage product (conic)
+\newcommand{\omegaf}{\omega^{\text{f}}}
+\newcommand{\omegat}{\omega^{\text{t}}}
+\newcommand{\omegar}{\omega^{\text{re}}}
+\newcommand{\omegai}{\omega^{\text{im}}}
+% Dispatch bounds (active/reactive)
+\newcommand{\muPg}{{\mu}^{\text{pg}}}
+\newcommand{\muPgMin}{\underline{\mu}^{\text{pg}}}
+\newcommand{\muPgMax}{\bar{\mu}^{\text{pg}}}
+\newcommand{\muQg}{{\mu}^{\text{qg}}}
+\newcommand{\muQgMin}{\underline{\mu}^{\text{qg}}}
+\newcommand{\muQgMax}{\bar{\mu}^{\text{qg}}}
+% Power flow bounds (active/reactive, to/fr)
+\newcommand{\muPf}{{\mu}^{\text{pf}}}
+\newcommand{\muPfMin}{\underline{\mu}^{\text{pf}}}
+\newcommand{\muPfMax}{\bar{\mu}^{\text{pf}}}
+\newcommand{\muQf}{{\mu}^{\text{qf}}}
+\newcommand{\muQfMin}{\underline{\mu}^{\text{qf}}}
+\newcommand{\muQfMax}{\bar{\mu}^{\text{qf}}}
+\newcommand{\muPt}{{\mu}^{\text{pt}}}
+\newcommand{\muPtMin}{\underline{\mu}^{\text{pt}}}
+\newcommand{\muPtMax}{\bar{\mu}^{\text{pt}}}
+\newcommand{\muQt}{{\mu}^{\text{qt}}}
+\newcommand{\muQtMin}{\underline{\mu}^{\text{qt}}}
+\newcommand{\muQtMax}{\bar{\mu}^{\text{qt}}}
+% Voltage magnitude bounds
+\newcommand{\muWm}{{\mu}^{\text{w}}}
+\newcommand{\muWmMin}{\underline{\mu}^{\text{w}}}
+\newcommand{\muWmMax}{\bar{\mu}^{\text{w}}}
+% Voltage product bounds
+\newcommand{\muWr}{{\mu}^{\text{wr}}}
+\newcommand{\muWrMin}{\underline{\mu}^{\text{wr}}}
+\newcommand{\muWrMax}{\bar{\mu}^{\text{wr}}}
+\newcommand{\muWi}{{\mu}^{\text{wi}}}
+\newcommand{\muWiMin}{\underline{\mu}^{\text{wi}}}
+\newcommand{\muWiMax}{\bar{\mu}^{\text{wi}}}
+% Angle difference bounds
+\newcommand{\muAngleDiff}{{\mu}^{\theta}}
+\newcommand{\muAngleDiffMin}{\underline{\mu}^{\theta}}
+\newcommand{\muAngleDiffMax}{\bar{\mu}^{\theta}}

--- a/docs/src/assets/wider.css
+++ b/docs/src/assets/wider.css
@@ -1,0 +1,3 @@
+.docs-main {
+    max-width: 55rem !important; /* default is 52 rem */
+}

--- a/docs/src/opf/acp.md
+++ b/docs/src/opf/acp.md
@@ -186,9 +186,9 @@ The objective function ``\eqref{eq:ACOPF:objective}`` minimizes the cost of acti
 | ``\eqref{eq:ACOPF:qg_bounds}`` (upper) | `qg_ub` | ``G`` | Reactive power generation upper bound
 | ``\eqref{eq:ACOPF:pf_bounds}`` (lower) | `pf_lb` | ``E`` | Active power flow (from) lower bound
 | ``\eqref{eq:ACOPF:pf_bounds}`` (upper) | `pf_ub` | ``E`` | Active power flow (from) upper bound
-| ``\eqref{eq:ACOPF:pf_bounds}`` (lower) | `qf_lb` | ``E`` | Reactive power flow (from) lower bound
-| ``\eqref{eq:ACOPF:pf_bounds}`` (upper) | `qf_ub` | ``E`` | Reactive power flow (from) upper bound
-| ``\eqref{eq:ACOPF:pf_bounds}`` (lower) | `pt_lb` | ``E`` | Active power flow (to) lower bound
-| ``\eqref{eq:ACOPF:pf_bounds}`` (upper) | `pt_ub` | ``E`` | Active power flow (to) upper bound
-| ``\eqref{eq:ACOPF:pf_bounds}`` (lower) | `qt_lb` | ``E`` | Reactive power flow (to) lower bound
-| ``\eqref{eq:ACOPF:pf_bounds}`` (upper) | `qt_ub` | ``E`` | Reactive power flow (to) upper bound
+| ``\eqref{eq:ACOPF:qf_bounds}`` (lower) | `qf_lb` | ``E`` | Reactive power flow (from) lower bound
+| ``\eqref{eq:ACOPF:qf_bounds}`` (upper) | `qf_ub` | ``E`` | Reactive power flow (from) upper bound
+| ``\eqref{eq:ACOPF:pt_bounds}`` (lower) | `pt_lb` | ``E`` | Active power flow (to) lower bound
+| ``\eqref{eq:ACOPF:pt_bounds}`` (upper) | `pt_ub` | ``E`` | Active power flow (to) upper bound
+| ``\eqref{eq:ACOPF:qt_bounds}`` (lower) | `qt_lb` | ``E`` | Reactive power flow (to) lower bound
+| ``\eqref{eq:ACOPF:qt_bounds}`` (upper) | `qt_ub` | ``E`` | Reactive power flow (to) upper bound

--- a/docs/src/opf/acp.md
+++ b/docs/src/opf/acp.md
@@ -10,10 +10,10 @@ The ACOPF model considered in OPFGenerator is presented below.
     \min_{\PG, \QG, \PF, \QF, \PT, \QT, \VM, \VA} \quad
     & \sum_{i \in \NODES} \sum_{j \in \GENERATORS_{i}} c_j \PG_j + c_0 \label{model:acopf:obj} \\
     \text{s.t.} \quad \quad \quad
-    & \sum_{j\in\GENERATORS_i}\PG_j - \sum_{j\in\LOADS_i}\PD_j - \GS_i \VM_i^2 = \sum_{e \in \mathcal{E}_{i}}  \PF_{e} + \sum_{e \in \mathcal{E}^R_{i}} \PT_{e}
+    & \sum_{j\in\GENERATORS_i}\PG_j - \sum_{j\in\LOADS_i}\PD_j - \GS_i \VM_i^2 = \sum_{e \in \mathcal{E}^{+}_{i}}  \PF_{e} + \sum_{e \in \mathcal{E}^{-}_{i}} \PT_{e}
         & \forall i &\in \NODES
         \label{model:acopf:kirchhoff:active} \\
-    & \sum_{j\in\GENERATORS_i}\QG_j - \sum_{j\in\LOADS_i}\QD_j + \BS_i \VM_i^2 = \sum_{e \in \mathcal{E}_{i}} \QF_{e} + \sum_{e \in \mathcal{E}^R_{i}} \QT_{e}
+    & \sum_{j\in\GENERATORS_i}\QG_j - \sum_{j\in\LOADS_i}\QD_j + \BS_i \VM_i^2 = \sum_{e \in \mathcal{E}^{+}_{i}} \QF_{e} + \sum_{e \in \mathcal{E}^{-}_{i}} \QT_{e}
         & \forall i &\in \NODES
         \label{model:acopf:kirchhoff:reactive} \\
     & \PF_{e} = \gff_{e}\VM_i^2 + \gft_{e} \VM_i \VM_j \cos(\VA_i-\VA_j) + \bft_{e} \VM_i \VM_j \sin(\VA_i-\VA_j)

--- a/docs/src/opf/acp.md
+++ b/docs/src/opf/acp.md
@@ -7,122 +7,77 @@ The ACOPF model considered in OPFGenerator is presented below.
 
 ```math
 \begin{align}
-    \min \quad 
-    & \label{eq:ACOPF:objective}
-        \sum_{g \in \mathcal{G}} c_{g} \mathbf{p}^{\text{g}}_{g} + c^{0}_{g}\\
-    \text{s.t.} \quad
-    & \label{eq:ACOPF:slack}
-        \boldsymbol{\theta}_{i_{s}} = 0\\
-    & \label{eq:ACOPF:kcl_p}
-        \sum_{g \in \mathcal{G}_{i}} \mathbf{p}^{\text{g}}_{g}
-        - \sum_{e \in \mathcal{E}^{+}_{i}} \mathbf{p}^{\text{f}}_{e}
-        - \sum_{e \in \mathcal{E}^{-}_{i}} \mathbf{p}^{\text{t}}_{e}
-        - g^{s}_{i} \mathbf{v}_{i}^{2}
-        =
-        \sum_{l \in \mathcal{L}_{i}} p^{d}_{l}
-        && \forall i \in \mathcal{N}
-        && [\lambda^{p}]\\
-    & \label{eq:ACOPF:kcl_q}
-        \sum_{g \in \mathcal{G}_{i}} \mathbf{q}^{\text{g}}_{g}
-        - \sum_{e \in \mathcal{E}^{+}_{i}} \mathbf{q}^{\text{f}}_{e}
-        - \sum_{e \in \mathcal{E}^{-}_{i}} \mathbf{q}^{\text{t}}_{e}
-        + b^{s}_{i} \mathbf{v}_{i}^{2}
-        =
-        \sum_{l \in \mathcal{L}_{i}} q^{d}_{l}
-        && \forall i \in \mathcal{N}
-        && [\lambda^{q}]\\
-    % Ohm's law
-    & \label{eq:ACOPF:ohm_pf}
-        g^{ff}_{e} \mathbf{v}_{i}^{2}
-        + g^{ft}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \cos (\Delta \theta_{e})
-        + b^{ft}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \sin (\Delta \theta_{e})
-        - \mathbf{p}^{\text{f}}_{e} = 0
-        && \forall e \in \mathcal{E}
-        && [\lambda^{pf}]\\
-    & \label{eq:ACOPF:ohm_qf}
-        -b^{ff}_{e} \mathbf{v}_{i}^{2}
-        - b^{ft}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \cos (\Delta \theta_{e})
-        + g^{ft}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \sin (\Delta \theta_{e})
-        - \mathbf{q}^{\text{f}}_{e} = 0
-        && \forall e \in \mathcal{E}
-        && [\lambda^{qf}]\\
-    & \label{eq:ACOPF:ohm_pt}
-        g^{tt}_{e} \mathbf{v}_{j}^{2}
-        + g^{tf}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \cos (\Delta \theta_{e})
-        - b^{tf}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \sin (\Delta \theta_{e})
-        - \mathbf{p}^{\text{t}}_{e} = 0
-        && \forall e \in \mathcal{E}
-        && [\lambda^{pt}]\\
-    & \label{eq:ACOPF:ohm_qt}
-        -b^{tt}_{e} \mathbf{v}_{j}^{2}
-        - b^{tf}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \cos (\Delta \theta_{e})
-        - g^{tf}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \sin (\Delta \theta_{e})
-        - \mathbf{q}^{\text{t}}_{e} = 0
-        && \forall e \in \mathcal{E}
-        && [\lambda^{qt}]\\
-    % Thermal limits
-    & \label{eq:ACOPF:sm_f}
-        (\mathbf{p}^{\text{f}}_{e})^{2} + (\mathbf{q}^{\text{f}}_{e})^{2} \leq \bar{s}_{e}^{2}
-        && \forall e \in \mathcal{E}
-        && [\nu^{f}]\\
-    & \label{eq:ACOPF:sm_t}
-        (\mathbf{p}^{\text{t}}_{e})^{2} + (\mathbf{q}^{\text{t}}_{e})^{2} \leq \bar{s}_{e}^{2}
-        && \forall e \in \mathcal{E}
-        && [\nu^{t}]\\
-    % Voltage angle deviation
-    & \label{eq:ACOPF:va_diff}
-        \underline{\Delta} \theta_{e} \leq \Delta \theta_{e}
-        \leq \bar{\Delta} \theta_{e}
-        && \forall e \in \mathcal{E}
-        && [\mu^{\Delta \theta}]\\
-    % Variable bounds
-    & \label{eq:ACOPF:vm_bounds}
-        \underline{v}_{i} \leq \mathbf{v}_{i} \leq \bar{v}_{i}, 
-        && \forall i \in \mathcal{N}
-        && [\mu^{v}]\\ 
-    & \label{eq:ACOPF:pg_bounds}
-        \underline{p}^{g}_{i} \leq \mathbf{p}^{\text{g}}_{i} \leq \bar{p}^{g}_{i}, 
-        && \forall i \in \mathcal{G}
-        && [\mu^{pg}]\\
-    & \label{eq:ACOPF:qg_bounds}
-        \underline{q}^{g}_{i} \leq \mathbf{q}^{\text{g}}_{i} \leq \bar{q}^{g}_{i},
-        && \forall i \in \mathcal{G}
-        && [\mu^{qg}]\\
-    & \label{eq:ACOPF:pf_bounds}
-        -\bar{s}_{e} \leq \mathbf{p}^{\text{f}}_{e} \leq \bar{s}_{e}
-        && \forall e \in \mathcal{E}
-        && [\mu^{pf}]\\
-    & \label{eq:ACOPF:qf_bounds}
-        -\bar{s}_{e} \leq \mathbf{q}^{\text{f}}_{e} \leq \bar{s}_{e}
-        && \forall e \in \mathcal{E}
-        && [\mu^{qf}]\\
-    & \label{eq:ACOPF:pt_bounds}
-        -\bar{s}_{e} \leq \mathbf{p}^{\text{t}}_{e} \leq \bar{s}_{e}
-        && \forall e \in \mathcal{E}
-        && [\mu^{pt}]\\
-    & \label{eq:ACOPF:qt_bounds}
-        -\bar{s}_{e} \leq \mathbf{q}^{\text{t}}_{e} \leq \bar{s}_{e}
-        && \forall e \in \mathcal{E}
-        && [\mu^{qt}]
+    \min_{\PG, \QG, \PF, \QF, \PT, \QT, \VM, \VA} \quad
+    & \sum_{i \in \NODES} \sum_{j \in \GENERATORS_{i}} c_j \PG_j \label{model:acopf:obj} \\
+    \text{s.t.} \quad \quad \quad
+    & \sum_{j\in\GENERATORS_i}\PG_j - \sum_{j\in\LOADS_i}\PD_j - \GS_i \VM_i^2 = \sum_{e \in \mathcal{E}_{i}}  \PF_{e} + \sum_{e \in \mathcal{E}^R_{i}} \PT_{e}
+        & \forall i &\in \NODES
+        \label{model:acopf:kirchhoff:active} \\
+    & \sum_{j\in\GENERATORS_i}\QG_j - \sum_{j\in\LOADS_i}\QD_j + \BS_i \VM_i^2 = \sum_{e \in \mathcal{E}_{i}} \QF_{e} + \sum_{e \in \mathcal{E}^R_{i}} \QT_{e}
+        & \forall i &\in \NODES
+        \label{model:acopf:kirchhoff:reactive} \\
+    & \PF_{e} = \gff_{e}\VM_i^2 + \gft_{e} \VM_i \VM_j \cos(\VA_i-\VA_j) + \bft_{e} \VM_i \VM_j \sin(\VA_i-\VA_j)
+        & \forall e = (i,j) &\in \EDGES
+        \label{model:acopf:ohm:active:from} \\
+    & \QF_{e} = -\bff_{e} \VM_i^2 - \bft_{e}\VM_i \VM_j \cos(\VA_i-\VA_j) + \gft_{e} \VM_i \VM_j \sin(\VA_i-\VA_j)
+        & \forall e = (i,j) &\in \EDGES
+        \label{model:acopf:ohm:reactive:from} \\
+    & \PT_{e} = \gtt_{e}\VM_j^2 + \gtf_{e} \VM_i \VM_j \cos(\VA_i-\VA_j) - \btf_{e} \VM_i \VM_j \sin(\VA_i-\VA_j)
+        & \forall e = (i,j) &\in \EDGES
+        \label{model:acopf:ohm:active:to} \\
+    & \QT_{e} = -\btt_{e} \VM_j^2 - \btf_{e}\VM_i \VM_j \cos(\VA_i-\VA_j) - \gtf_{e} \VM_i \VM_j \sin(\VA_i-\VA_j)
+        & \forall e = (i,j) &\in \EDGES
+        \label{model:acopf:ohm:reactive:to} \\
+    & (\PF_{e})^2 + (\QF_{e})^2 \leq \overline{S_{e}}^2
+        & \forall e &\in \EDGES
+        \label{model:acopf:thrmbound:from} \\
+    & (\PT_{e})^2 + (\QT_{e})^2 \leq \overline{S_{e}}^2
+        & \forall e &\in \EDGES
+        \label{model:acopf:thrmbound:to} \\
+    & \dvamin_{e} \leq \VA_i - \VA_j \leq \dvamax_{e}
+        & \forall e = (i,j) &\in \EDGES
+        \label{model:acopf:angledifference} \\
+    & \VA_\text{ref} = 0
+        \label{model:acopf:slackbus} \\
+    & \pgmin_{i} \leq \PG_i \leq \pgmax_{i}
+        & \forall i &\in \GENERATORS
+        \label{model:acopf:pgbound} \\
+    & \qgmin_{i} \leq \QG_i \leq \qgmax_{i}
+        & \forall i &\in \GENERATORS
+        \label{model:acopf:qgbound} \\
+    & \underline{\VM_i} \leq \VM_i \leq \overline{\VM_i}
+        & \forall i &\in \NODES
+        \label{model:acopf:vmbound} \\
+    & {-}\overline{S_{e}} \leq  \PF_{e} \leq \overline{S_{e}}
+        & \forall e &\in \EDGES
+        \label{model:acopf:pfbound} \\
+    & {-}\overline{S_{e}} \leq  \QF_{e} \leq \overline{S_{e}}
+        & \forall e &\in \EDGES
+        \label{model:acopf:qfbound} \\
+    & {-}\overline{S_{e}} \leq  \PT_{e} \leq \overline{S_{e}}
+        & \forall e &\in \EDGES
+        \label{model:acopf:ptbound} \\
+    & {-}\overline{S_{e}} \leq  \QT_{e} \leq \overline{S_{e}}
+        & \forall e &\in \EDGES
+        \label{model:acopf:qtbound}
 \end{align}
 ```
-where ``\Delta \theta_{e} = \boldsymbol{\theta}_{i} - \boldsymbol{\theta}_{j}`` for branch ``e = (i, j) \in \mathcal{E}``.
 
 
 ### Variables
 
-* ``\mathbf{v} \in \mathbb{R}^{N}``: nodal voltage magnitude
-* ``\boldsymbol{\theta} \in \mathbb{R}^{N}``: nodal voltage angle
-* ``\mathbf{p}^{\text{g}} \in \mathbb{R}^{G}``: active power dispatch
-* ``\mathbf{q}^{\text{g}} \in \mathbb{R}^{G}``: reactive power dispatch
-* ``\mathbf{p}^{\text{f}} \in \mathbb{R}^{E}``: active power flow "from"
-* ``\mathbf{q}^{\text{f}} \in \mathbb{R}^{E}``: reactive power flow "from"
-* ``\mathbf{p}^{\text{t}} \in \mathbb{R}^{E}``: active power flow "to"
-* ``\mathbf{q}^{\text{t}} \in \mathbb{R}^{E}``: reactive power flow "to"
+* ``\VM \in \mathbb{R}^{N}``: nodal voltage magnitude
+* ``\VA \in \mathbb{R}^{N}``: nodal voltage angle
+* ``\PG \in \mathbb{R}^{G}``: active power dispatch
+* ``\QG \in \mathbb{R}^{G}``: reactive power dispatch
+* ``\PF \in \mathbb{R}^{E}``: active power flow "from"
+* ``\QF \in \mathbb{R}^{E}``: reactive power flow "from"
+* ``\PT \in \mathbb{R}^{E}``: active power flow "to"
+* ``\QT \in \mathbb{R}^{E}``: reactive power flow "to"
 
 ### Objective
 
-The objective function ``\eqref{eq:ACOPF:objective}`` minimizes the cost of active power generation.
+The objective function ``\eqref{model:acopf:obj}`` minimizes the cost of active power generation.
 
 !!! todo
     OPFGenerator currently supports only linear cost functions.
@@ -131,21 +86,21 @@ The objective function ``\eqref{eq:ACOPF:objective}`` minimizes the cost of acti
 
 ### Constraints
 
-* ``\eqref{eq:ACOPF:slack}``: this constraint fixes the voltage angle of the 
-    reference (slack) bus to zero.
-* ``\eqref{eq:ACOPF:kcl_p}-\eqref{eq:ACOPF:kcl_q}``:
+* ``\eqref{model:acopf:kirchhoff:active}-\eqref{model:acopf:kirchhoff:reactive}``:
     active and reactive Kirchhoff's current law.
-* ``\eqref{eq:ACOPF:ohm_pf}-\eqref{eq:ACOPF:ohm_qt}``:
+* ``\eqref{model:acopf:ohm:active:from}-\eqref{model:acopf:ohm:reactive:to}``:
     Ohm's law expressing power flows as a function of nodal voltages.
-* ``\eqref{eq:ACOPF:sm_f}-\eqref{eq:ACOPF:sm_t}``: Thermal limits
-* ``\eqref{eq:ACOPF:va_diff}``: Voltage angle deviation constraints.
-* ``\eqref{eq:ACOPF:vm_bounds}``: Nodal voltage angle limits
-* ``\eqref{eq:ACOPF:pg_bounds}-\eqref{eq:ACOPF:qg_bounds}``: Active/reactive generation limits
-* ``\eqref{eq:ACOPF:pf_bounds}-\eqref{eq:ACOPF:qt_bounds}``: Power flow bounds, derived from thermal limits
+* ``\eqref{model:acopf:thrmbound:from}-\eqref{model:acopf:thrmbound:to}``: Thermal limits
+* ``\eqref{model:acopf:angledifference}``: Voltage angle deviation constraints.
+* ``\eqref{model:acopf:slackbus}``: this constraint fixes the voltage angle of the 
+    reference (slack) bus to zero.
+* ``\eqref{model:acopf:pgbound}-\eqref{model:acopf:qgbound}``: Active/reactive generation limits
+* ``\eqref{model:acopf:vmbound}``: Nodal voltage angle limits
+* ``\eqref{model:acopf:pfbound}-\eqref{model:acopf:qtbound}``: Power flow bounds, derived from thermal limits
 
 !!! info
-    Although power flow variable bounds``\eqref{eq:ACOPF:pf_bounds}-\eqref{eq:ACOPF:qt_bounds}``
-    are redundant with thermal limits ``\eqref{eq:ACOPF:sm_f}-\eqref{eq:ACOPF:sm_t}``, 
+    Although power flow variable bounds ``\eqref{model:acopf:pfbound}-\eqref{model:acopf:qtbound}``
+    are redundant with thermal limits ``\eqref{model:acopf:thrmbound:from}-\eqref{model:acopf:thrmbound:to}``, 
     their inclusion improves the performance of interior-point solvers like Ipopt.
 
 
@@ -153,42 +108,42 @@ The objective function ``\eqref{eq:ACOPF:objective}`` minimizes the cost of acti
 
 ### Primal solution
 
-| Variable                  | Data | Size  | Description 
-|:--------------------------|:-----|:------|:----------------------------------|
-| ``\mathbf{v}``            | `vm` | ``N`` | Nodal voltage magnitude
-| ``\boldsymbol{\theta}``   | `va` | ``N`` | Nodal voltage angle
-| ``\mathbf{p}^{\text{g}}`` | `pg` | ``G`` | Active power generation
-| ``\mathbf{q}^{\text{g}}`` | `pg` | ``G`` | Reactive power generation
-| ``\mathbf{p}^{\text{f}}`` | `pf` | ``E`` | Active power flow (from)
-| ``\mathbf{p}^{\text{t}}`` | `pt` | ``E`` | Active power flow (to)
-| ``\mathbf{q}^{\text{f}}`` | `qf` | ``E`` | Reactive power flow (from)
-| ``\mathbf{q}^{\text{t}}`` | `qt` | ``E`` | Reactive power flow (to)
+| Variable  | Data | Size  | Description 
+|:----------|:-----|:------|:----------------------------------|
+|  ``\VM``  | `vm` | ``N`` | Nodal voltage magnitude
+|  ``\VA``  | `va` | ``N`` | Nodal voltage angle
+|  ``\PG``  | `pg` | ``G`` | Active power generation
+|  ``\QG``  | `pg` | ``G`` | Reactive power generation
+|  ``\PF``  | `pf` | ``E`` | Active power flow (from)
+|  ``\PT``  | `pt` | ``E`` | Active power flow (to)
+|  ``\QF``  | `qf` | ``E`` | Reactive power flow (from)
+|  ``\QT``  | `qt` | ``E`` | Reactive power flow (to)
 
 ### Dual solution
 
-| Constraint                     | Data | Size  | Domain 
-|:-------------------------------|:-----|:------|:----------------------------------|
-| ``\eqref{eq:ACOPF:slack}``     | `slack_bus`  | ``N`` | Nodal voltage magnitude
-| ``\eqref{eq:ACOPF:kcl_p}``     | `kcl_p`      | ``N`` | Nodal voltage angle
-| ``\eqref{eq:ACOPF:kcl_q}``     | `kcl_q`      | ``N`` | Active power generation
-| ``\eqref{eq:ACOPF:ohm_pf}``    | `ohm_pf`     | ``E`` | Reactive power generation
-| ``\eqref{eq:ACOPF:ohm_qf}``    | `ohm_qf` | ``E`` | Active power flow (to)
-| ``\eqref{eq:ACOPF:ohm_pt}``    | `ohm_pt` | ``E`` | Active power flow (from)
-| ``\eqref{eq:ACOPF:ohm_qt}``    | `ohm_qt` | ``E`` | Reactive power flow (from)
-| ``\eqref{eq:ACOPF:sm_f}``      | `sm_fr` | ``E`` | Reactive power flow (to)
-| ``\eqref{eq:ACOPF:sm_t}``      | `sm_to` | ``E`` | Reactive power flow (to)
-| ``\eqref{eq:ACOPF:va_diff}``   | `va_diff` | ``E`` | Reactive power flow (to)
-| ``\eqref{eq:ACOPF:vm_bounds}`` (lower) | `vm_lb` | ``N`` | Voltage magnitude lower bounds
-| ``\eqref{eq:ACOPF:vm_bounds}`` (upper) | `vm_ub` | ``N`` | Voltage magnitude upper bounds
-| ``\eqref{eq:ACOPF:pg_bounds}`` (lower) | `pg_lb` | ``G`` | Active power generation lower bound
-| ``\eqref{eq:ACOPF:pg_bounds}`` (upper) | `pg_ub` | ``G`` | Active power generation upper bound
-| ``\eqref{eq:ACOPF:qg_bounds}`` (lower) | `qg_lb` | ``G`` | Reactive power generation lower bound
-| ``\eqref{eq:ACOPF:qg_bounds}`` (upper) | `qg_ub` | ``G`` | Reactive power generation upper bound
-| ``\eqref{eq:ACOPF:pf_bounds}`` (lower) | `pf_lb` | ``E`` | Active power flow (from) lower bound
-| ``\eqref{eq:ACOPF:pf_bounds}`` (upper) | `pf_ub` | ``E`` | Active power flow (from) upper bound
-| ``\eqref{eq:ACOPF:qf_bounds}`` (lower) | `qf_lb` | ``E`` | Reactive power flow (from) lower bound
-| ``\eqref{eq:ACOPF:qf_bounds}`` (upper) | `qf_ub` | ``E`` | Reactive power flow (from) upper bound
-| ``\eqref{eq:ACOPF:pt_bounds}`` (lower) | `pt_lb` | ``E`` | Active power flow (to) lower bound
-| ``\eqref{eq:ACOPF:pt_bounds}`` (upper) | `pt_ub` | ``E`` | Active power flow (to) upper bound
-| ``\eqref{eq:ACOPF:qt_bounds}`` (lower) | `qt_lb` | ``E`` | Reactive power flow (to) lower bound
-| ``\eqref{eq:ACOPF:qt_bounds}`` (upper) | `qt_ub` | ``E`` | Reactive power flow (to) upper bound
+| Constraint                                   | Data         | Size  | Domain 
+|:---------------------------------------------|:-------------|:------|:----------------------------------|
+| ``\eqref{model:acopf:kirchhoff:active}``     | `kcl_p`      | ``N`` | Nodal voltage angle
+| ``\eqref{model:acopf:kirchhoff:reactive}``   | `kcl_q`      | ``N`` | Active power generation
+| ``\eqref{model:acopf:ohm:active:from}``      | `ohm_pf`     | ``E`` | Reactive power generation
+| ``\eqref{model:acopf:ohm:reactive:from}``    | `ohm_qf`     | ``E`` | Active power flow (to)
+| ``\eqref{model:acopf:ohm:active:to}``        | `ohm_pt`     | ``E`` | Active power flow (from)
+| ``\eqref{model:acopf:ohm:reactive:to}``      | `ohm_qt`     | ``E`` | Reactive power flow (from)
+| ``\eqref{model:acopf:thrmbound:from}``       | `sm_fr`      | ``E`` | Reactive power flow (to)
+| ``\eqref{model:acopf:thrmbound:to}``         | `sm_to`      | ``E`` | Reactive power flow (to)
+| ``\eqref{model:acopf:angledifference}``      | `va_diff`    | ``E`` | Reactive power flow (to)
+| ``\eqref{model:acopf:slackbus}``             | `slack_bus`  | ``N`` | Nodal voltage magnitude
+| ``\eqref{model:acopf:pgbound}`` (lower)      | `pg_lb`      | ``G`` | Active power generation lower bound
+| ``\eqref{model:acopf:pgbound}`` (upper)      | `pg_ub`      | ``G`` | Active power generation upper bound
+| ``\eqref{model:acopf:qgbound}`` (lower)      | `qg_lb`      | ``G`` | Reactive power generation lower bound
+| ``\eqref{model:acopf:qgbound}`` (upper)      | `qg_ub`      | ``G`` | Reactive power generation upper bound
+| ``\eqref{model:acopf:vmbound}`` (lower)      | `vm_lb`      | ``N`` | Voltage magnitude lower bounds
+| ``\eqref{model:acopf:vmbound}`` (upper)      | `vm_ub`      | ``N`` | Voltage magnitude upper bounds
+| ``\eqref{model:acopf:pfbound}`` (lower)      | `pf_lb`      | ``E`` | Active power flow (from) lower bound
+| ``\eqref{model:acopf:pfbound}`` (upper)      | `pf_ub`      | ``E`` | Active power flow (from) upper bound
+| ``\eqref{model:acopf:qfbound}`` (lower)      | `qf_lb`      | ``E`` | Reactive power flow (from) lower bound
+| ``\eqref{model:acopf:qfbound}`` (upper)      | `qf_ub`      | ``E`` | Reactive power flow (from) upper bound
+| ``\eqref{model:acopf:ptbound}`` (lower)      | `pt_lb`      | ``E`` | Active power flow (to) lower bound
+| ``\eqref{model:acopf:ptbound}`` (upper)      | `pt_ub`      | ``E`` | Active power flow (to) upper bound
+| ``\eqref{model:acopf:qtbound}`` (lower)      | `qt_lb`      | ``E`` | Reactive power flow (to) lower bound
+| ``\eqref{model:acopf:qtbound}`` (upper)      | `qt_ub`      | ``E`` | Reactive power flow (to) upper bound

--- a/docs/src/opf/acp.md
+++ b/docs/src/opf/acp.md
@@ -121,29 +121,29 @@ The objective function ``\eqref{model:acopf:obj}`` minimizes the cost of active 
 
 ### Dual solution
 
-| Constraint                                   | Data         | Size  | Domain 
-|:---------------------------------------------|:-------------|:------|:----------------------------------|
-| ``\eqref{model:acopf:kirchhoff:active}``     | `kcl_p`      | ``N`` | Nodal voltage angle
-| ``\eqref{model:acopf:kirchhoff:reactive}``   | `kcl_q`      | ``N`` | Active power generation
-| ``\eqref{model:acopf:ohm:active:from}``      | `ohm_pf`     | ``E`` | Reactive power generation
-| ``\eqref{model:acopf:ohm:reactive:from}``    | `ohm_qf`     | ``E`` | Active power flow (to)
-| ``\eqref{model:acopf:ohm:active:to}``        | `ohm_pt`     | ``E`` | Active power flow (from)
-| ``\eqref{model:acopf:ohm:reactive:to}``      | `ohm_qt`     | ``E`` | Reactive power flow (from)
-| ``\eqref{model:acopf:thrmbound:from}``       | `sm_fr`      | ``E`` | Reactive power flow (to)
-| ``\eqref{model:acopf:thrmbound:to}``         | `sm_to`      | ``E`` | Reactive power flow (to)
-| ``\eqref{model:acopf:angledifference}``      | `va_diff`    | ``E`` | Reactive power flow (to)
-| ``\eqref{model:acopf:slackbus}``             | `slack_bus`  | ``N`` | Nodal voltage magnitude
-| ``\eqref{model:acopf:pgbound}`` (lower)      | `pg_lb`      | ``G`` | Active power generation lower bound
-| ``\eqref{model:acopf:pgbound}`` (upper)      | `pg_ub`      | ``G`` | Active power generation upper bound
-| ``\eqref{model:acopf:qgbound}`` (lower)      | `qg_lb`      | ``G`` | Reactive power generation lower bound
-| ``\eqref{model:acopf:qgbound}`` (upper)      | `qg_ub`      | ``G`` | Reactive power generation upper bound
-| ``\eqref{model:acopf:vmbound}`` (lower)      | `vm_lb`      | ``N`` | Voltage magnitude lower bounds
-| ``\eqref{model:acopf:vmbound}`` (upper)      | `vm_ub`      | ``N`` | Voltage magnitude upper bounds
-| ``\eqref{model:acopf:pfbound}`` (lower)      | `pf_lb`      | ``E`` | Active power flow (from) lower bound
-| ``\eqref{model:acopf:pfbound}`` (upper)      | `pf_ub`      | ``E`` | Active power flow (from) upper bound
-| ``\eqref{model:acopf:qfbound}`` (lower)      | `qf_lb`      | ``E`` | Reactive power flow (from) lower bound
-| ``\eqref{model:acopf:qfbound}`` (upper)      | `qf_ub`      | ``E`` | Reactive power flow (from) upper bound
-| ``\eqref{model:acopf:ptbound}`` (lower)      | `pt_lb`      | ``E`` | Active power flow (to) lower bound
-| ``\eqref{model:acopf:ptbound}`` (upper)      | `pt_ub`      | ``E`` | Active power flow (to) upper bound
-| ``\eqref{model:acopf:qtbound}`` (lower)      | `qt_lb`      | ``E`` | Reactive power flow (to) lower bound
-| ``\eqref{model:acopf:qtbound}`` (upper)      | `qt_ub`      | ``E`` | Reactive power flow (to) upper bound
+| Constraint                                   | Data         | Size  |
+|:---------------------------------------------|:-------------|:------|
+| ``\eqref{model:acopf:kirchhoff:active}``     | `kcl_p`      | ``N`` |
+| ``\eqref{model:acopf:kirchhoff:reactive}``   | `kcl_q`      | ``N`` |
+| ``\eqref{model:acopf:ohm:active:from}``      | `ohm_pf`     | ``E`` |
+| ``\eqref{model:acopf:ohm:reactive:from}``    | `ohm_qf`     | ``E`` |
+| ``\eqref{model:acopf:ohm:active:to}``        | `ohm_pt`     | ``E`` |
+| ``\eqref{model:acopf:ohm:reactive:to}``      | `ohm_qt`     | ``E`` |
+| ``\eqref{model:acopf:thrmbound:from}``       | `sm_fr`      | ``E`` |
+| ``\eqref{model:acopf:thrmbound:to}``         | `sm_to`      | ``E`` |
+| ``\eqref{model:acopf:angledifference}``      | `va_diff`    | ``E`` |
+| ``\eqref{model:acopf:slackbus}``             | `slack_bus`  | ``N`` |
+| ``\eqref{model:acopf:pgbound}`` (lower)      | `pg_lb`      | ``G`` |
+| ``\eqref{model:acopf:pgbound}`` (upper)      | `pg_ub`      | ``G`` |
+| ``\eqref{model:acopf:qgbound}`` (lower)      | `qg_lb`      | ``G`` |
+| ``\eqref{model:acopf:qgbound}`` (upper)      | `qg_ub`      | ``G`` |
+| ``\eqref{model:acopf:vmbound}`` (lower)      | `vm_lb`      | ``N`` |
+| ``\eqref{model:acopf:vmbound}`` (upper)      | `vm_ub`      | ``N`` |
+| ``\eqref{model:acopf:pfbound}`` (lower)      | `pf_lb`      | ``E`` |
+| ``\eqref{model:acopf:pfbound}`` (upper)      | `pf_ub`      | ``E`` |
+| ``\eqref{model:acopf:qfbound}`` (lower)      | `qf_lb`      | ``E`` |
+| ``\eqref{model:acopf:qfbound}`` (upper)      | `qf_ub`      | ``E`` |
+| ``\eqref{model:acopf:ptbound}`` (lower)      | `pt_lb`      | ``E`` |
+| ``\eqref{model:acopf:ptbound}`` (upper)      | `pt_ub`      | ``E`` |
+| ``\eqref{model:acopf:qtbound}`` (lower)      | `qt_lb`      | ``E`` |
+| ``\eqref{model:acopf:qtbound}`` (upper)      | `qt_ub`      | ``E`` |

--- a/docs/src/opf/acp.md
+++ b/docs/src/opf/acp.md
@@ -45,19 +45,19 @@ The ACOPF model considered in OPFGenerator is presented below.
     & \qgmin_{i} \leq \QG_i \leq \qgmax_{i}
         & \forall i &\in \GENERATORS
         \label{model:acopf:qgbound} \\
-    & \underline{\VM_i} \leq \VM_i \leq \overline{\VM_i}
+    & \vmmin_{i} \leq \VM_i \leq \vmmax_{i}
         & \forall i &\in \NODES
         \label{model:acopf:vmbound} \\
-    & {-}\overline{S_{e}} \leq  \PF_{e} \leq \overline{S_{e}}
+    & {-}\overline{S}_{e} \leq  \PF_{e} \leq \overline{S}_{e}
         & \forall e &\in \EDGES
         \label{model:acopf:pfbound} \\
-    & {-}\overline{S_{e}} \leq  \QF_{e} \leq \overline{S_{e}}
+    & {-}\overline{S}_{e} \leq  \QF_{e} \leq \overline{S}_{e}
         & \forall e &\in \EDGES
         \label{model:acopf:qfbound} \\
-    & {-}\overline{S_{e}} \leq  \PT_{e} \leq \overline{S_{e}}
+    & {-}\overline{S}_{e} \leq  \PT_{e} \leq \overline{S}_{e}
         & \forall e &\in \EDGES
         \label{model:acopf:ptbound} \\
-    & {-}\overline{S_{e}} \leq  \QT_{e} \leq \overline{S_{e}}
+    & {-}\overline{S}_{e} \leq  \QT_{e} \leq \overline{S}_{e}
         & \forall e &\in \EDGES
         \label{model:acopf:qtbound}
 \end{align}

--- a/docs/src/opf/acp.md
+++ b/docs/src/opf/acp.md
@@ -1,88 +1,118 @@
 # AC-OPF
 
+
+## Mathematical Formulation
+
 The ACOPF model considered in OPFGenerator is presented below.
 
 ```math
 \begin{align}
     \min \quad 
-    & \sum_{g \in \mathcal{G}} c_{g} \mathbf{p}^{\text{g}}_{g} + c^{0}_{g}\\
+    & \label{eq:ACOPF:objective}
+        \sum_{g \in \mathcal{G}} c_{g} \mathbf{p}^{\text{g}}_{g} + c^{0}_{g}\\
     \text{s.t.} \quad
-    & \theta_{i_{s}} = 0\\
-    & \sum_{g \in \mathcal{G}_{i}} \mathbf{p}^{\text{g}}_{g}
+    & \label{eq:ACOPF:slack}
+        \boldsymbol{\theta}_{i_{s}} = 0\\
+    & \label{eq:ACOPF:kcl_p}
+        \sum_{g \in \mathcal{G}_{i}} \mathbf{p}^{\text{g}}_{g}
         - \sum_{e \in \mathcal{E}^{+}_{i}} \mathbf{p}^{\text{f}}_{e}
         - \sum_{e \in \mathcal{E}^{-}_{i}} \mathbf{p}^{\text{t}}_{e}
         - g^{s}_{i} \mathbf{v}_{i}^{2}
         =
         \sum_{l \in \mathcal{L}_{i}} p^{d}_{l}
-        & \forall i \in \mathcal{N}
-        &&& [\lambda^{p}]\\
-    & \sum_{g \in \mathcal{G}_{i}} \mathbf{q}^{\text{g}}_{g}
+        && \forall i \in \mathcal{N}
+        && [\lambda^{p}]\\
+    & \label{eq:ACOPF:kcl_q}
+        \sum_{g \in \mathcal{G}_{i}} \mathbf{q}^{\text{g}}_{g}
         - \sum_{e \in \mathcal{E}^{+}_{i}} \mathbf{q}^{\text{f}}_{e}
         - \sum_{e \in \mathcal{E}^{-}_{i}} \mathbf{q}^{\text{t}}_{e}
         + b^{s}_{i} \mathbf{v}_{i}^{2}
         =
         \sum_{l \in \mathcal{L}_{i}} q^{d}_{l}
-        & \forall i \in \mathcal{N}
-        &&& [\lambda^{q}]\\
+        && \forall i \in \mathcal{N}
+        && [\lambda^{q}]\\
     % Ohm's law
-    & g^{ff}_{e} \mathbf{v}_{i}^{2}
+    & \label{eq:ACOPF:ohm_pf}
+        g^{ff}_{e} \mathbf{v}_{i}^{2}
         + g^{ft}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \cos (\Delta \theta_{e})
         + b^{ft}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \sin (\Delta \theta_{e})
         - \mathbf{p}^{\text{f}}_{e} = 0
-        & \forall e \in \mathcal{E}
-        &&& [\lambda^{pf}]\\
-    & -b^{ff}_{e} \mathbf{v}_{i}^{2}
+        && \forall e \in \mathcal{E}
+        && [\lambda^{pf}]\\
+    & \label{eq:ACOPF:ohm_qf}
+        -b^{ff}_{e} \mathbf{v}_{i}^{2}
         - b^{ft}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \cos (\Delta \theta_{e})
         + g^{ft}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \sin (\Delta \theta_{e})
         - \mathbf{q}^{\text{f}}_{e} = 0
-        & \forall e \in \mathcal{E}
-        &&& [\lambda^{qf}]\\
-    & g^{tt}_{e} \mathbf{v}_{j}^{2}
+        && \forall e \in \mathcal{E}
+        && [\lambda^{qf}]\\
+    & \label{eq:ACOPF:ohm_pt}
+        g^{tt}_{e} \mathbf{v}_{j}^{2}
         + g^{tf}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \cos (\Delta \theta_{e})
         - b^{tf}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \sin (\Delta \theta_{e})
         - \mathbf{p}^{\text{t}}_{e} = 0
-        & \forall e \in \mathcal{E}
-        &&& [\lambda^{pt}]\\
-    & -b^{tt}_{e} \mathbf{v}_{j}^{2}
+        && \forall e \in \mathcal{E}
+        && [\lambda^{pt}]\\
+    & \label{eq:ACOPF:ohm_qt}
+        -b^{tt}_{e} \mathbf{v}_{j}^{2}
         - b^{tf}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \cos (\Delta \theta_{e})
         - g^{tf}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \sin (\Delta \theta_{e})
         - \mathbf{q}^{\text{t}}_{e} = 0
-        & \forall e \in \mathcal{E}
-        &&& [\lambda^{qt}]\\
+        && \forall e \in \mathcal{E}
+        && [\lambda^{qt}]\\
     % Thermal limits
-    & (\mathbf{p}^{\text{f}}_{e})^{2} + (\mathbf{q}^{\text{f}}_{e})^{2} \leq \bar{s}_{e}^{2}
-        & \forall e \in \mathcal{E}
-        &&& [\nu^{f}]\\
-    & (\mathbf{p}^{\text{t}}_{e})^{2} + (\mathbf{q}^{\text{t}}_{e})^{2} \leq \bar{s}_{e}^{2}
-        & \forall e \in \mathcal{E}
-        &&& [\nu^{t}]\\
+    & \label{eq:ACOPF:sm_f}
+        (\mathbf{p}^{\text{f}}_{e})^{2} + (\mathbf{q}^{\text{f}}_{e})^{2} \leq \bar{s}_{e}^{2}
+        && \forall e \in \mathcal{E}
+        && [\nu^{f}]\\
+    & \label{eq:ACOPF:sm_t}
+        (\mathbf{p}^{\text{t}}_{e})^{2} + (\mathbf{q}^{\text{t}}_{e})^{2} \leq \bar{s}_{e}^{2}
+        && \forall e \in \mathcal{E}
+        && [\nu^{t}]\\
     % Voltage angle deviation
-    & \underline{\Delta} \theta_{e} \leq \Delta \theta_{e}
+    & \label{eq:ACOPF:va_diff}
+        \underline{\Delta} \theta_{e} \leq \Delta \theta_{e}
         \leq \bar{\Delta} \theta_{e}
-        & \forall e \in \mathcal{E}
-        &&& [\mu^{\Delta \theta}]\\
+        && \forall e \in \mathcal{E}
+        && [\mu^{\Delta \theta}]\\
     % Variable bounds
-    & \underline{v}_{i} \leq \mathbf{v}_{i} \leq \bar{v}_{i}, 
-        & \forall i \in \mathcal{N}
-        &&& [\mu^{v}]\\ 
-    & \underline{p}^{g}_{i} \leq \mathbf{p}^{\text{g}}_{i} \leq \bar{p}^{g}_{i}, 
-        & \forall i \in \mathcal{G}
-        &&& [\mu^{pg}]\\
-    & \underline{q}^{g}_{i} \leq p^{q}_{i} \leq \bar{q}^{g}_{i},
-        & \forall i \in \mathcal{G}
-        &&& [\mu^{qg}]\\
-    & -\bar{s}_{e} \leq \mathbf{p}^{\text{f}}_{e}, \mathbf{q}^{\text{f}}_{e}, \mathbf{p}^{\text{t}}_{e}, \mathbf{q}^{\text{t}}_{e} \leq \bar{s}_{e}
-        & \forall e \in \mathcal{E}
-        &&& [\mu^{pf,qf,pt,qt}]
+    & \label{eq:ACOPF:vm_bounds}
+        \underline{v}_{i} \leq \mathbf{v}_{i} \leq \bar{v}_{i}, 
+        && \forall i \in \mathcal{N}
+        && [\mu^{v}]\\ 
+    & \label{eq:ACOPF:pg_bounds}
+        \underline{p}^{g}_{i} \leq \mathbf{p}^{\text{g}}_{i} \leq \bar{p}^{g}_{i}, 
+        && \forall i \in \mathcal{G}
+        && [\mu^{pg}]\\
+    & \label{eq:ACOPF:qg_bounds}
+        \underline{q}^{g}_{i} \leq p^{q}_{i} \leq \bar{q}^{g}_{i},
+        && \forall i \in \mathcal{G}
+        && [\mu^{qg}]\\
+    & \label{eq:ACOPF:pf_bounds}
+        -\bar{s}_{e} \leq \mathbf{p}^{\text{f}}_{e} \leq \bar{s}_{e}
+        && \forall e \in \mathcal{E}
+        && [\mu^{pf}]\\
+    & \label{eq:ACOPF:qf_bounds}
+        -\bar{s}_{e} \leq \mathbf{q}^{\text{f}}_{e} \leq \bar{s}_{e}
+        && \forall e \in \mathcal{E}
+        && [\mu^{qf}]\\
+    & \label{eq:ACOPF:pt_bounds}
+        -\bar{s}_{e} \leq \mathbf{p}^{\text{t}}_{e} \leq \bar{s}_{e}
+        && \forall e \in \mathcal{E}
+        && [\mu^{pt}]\\
+    & \label{eq:ACOPF:qt_bounds}
+        -\bar{s}_{e} \leq \mathbf{q}^{\text{t}}_{e} \leq \bar{s}_{e}
+        && \forall e \in \mathcal{E}
+        && [\mu^{qt}]
 \end{align}
 ```
-where ``\Delta \theta_{e} = \theta_{i} - \theta_{j}`` for branch ``e = (i, j) \in \mathcal{E}``.
+where ``\Delta \theta_{e} = \boldsymbol{\theta}_{i} - \boldsymbol{\theta}_{j}`` for branch ``e = (i, j) \in \mathcal{E}``.
 
 
-## Variables
+### Variables
 
-* ``v \in \mathbb{R}^{N}``: nodal voltage magnitude
-* ``\theta \in \mathbb{R}^{N}``: nodal voltage angle
+* ``\mathbf{v} \in \mathbb{R}^{N}``: nodal voltage magnitude
+* ``\boldsymbol{\theta} \in \mathbb{R}^{N}``: nodal voltage angle
 * ``\mathbf{p}^{\text{g}} \in \mathbb{R}^{G}``: active power dispatch
 * ``\mathbf{q}^{\text{g}} \in \mathbb{R}^{G}``: reactive power dispatch
 * ``\mathbf{p}^{\text{f}} \in \mathbb{R}^{E}``: active power flow "from"
@@ -90,99 +120,75 @@ where ``\Delta \theta_{e} = \theta_{i} - \theta_{j}`` for branch ``e = (i, j) \i
 * ``\mathbf{p}^{\text{t}} \in \mathbb{R}^{E}``: active power flow "to"
 * ``\mathbf{q}^{\text{t}} \in \mathbb{R}^{E}``: reactive power flow "to"
 
-## Objective
+### Objective
 
-The objective function minimizes the cost of active power generation.
-OPFGenerator currently supports only linear cost functions.
+The objective function ``\eqref{eq:ACOPF:objective}`` minimizes the cost of active power generation.
 
-## Constraints
+!!! todo
+    OPFGenerator currently supports only linear cost functions.
+    Support for quadratic functions is planned for a later stage; please open an issue if 
+    you would like to request this feature.
 
+### Constraints
 
-### Slack bus reference angle
-
-The slack bus reference angle constraint sets the voltage angle to zero at the slack bus.
-```math
-\theta_{i_{s}} = 0
-```
-where ``i_{s}`` is the index of the slack bus.
-
-### Kirchhoff current law
-
-Kirchhoff's current law (also known as "nodal power balance") for bus ``i \in \mathcal{N}``
-reads, for active power
-```math
-\sum_{g \in \mathcal{G}_{i}} \mathbf{p}^{\text{g}}_{g}
-- \sum_{e \in \mathcal{E}^{+}_{i}} \mathbf{p}^{\text{f}}_{e}
-- \sum_{e \in \mathcal{E}^{-}_{i}} \mathbf{p}^{\text{t}}_{e}
-- g^{s}_{i} \mathbf{v}_{i}^{2}
-=
-\sum_{l \in \mathcal{L}_{i}} p^{d}_{l}
-```
-and for reactive power
-```math
-\sum_{g \in \mathcal{G}_{i}} \mathbf{q}^{\text{g}}_{g}
-- \sum_{e \in \mathcal{E}^{+}_{i}} \mathbf{q}^{\text{f}}_{e}
-- \sum_{e \in \mathcal{E}^{-}_{i}} \mathbf{q}^{\text{t}}_{e}
-+ b^{s}_{i} \mathbf{v}_{i}^{2}
-=
-\sum_{l \in \mathcal{L}_{i}} q^{d}_{l}
-```
-
-### Ohm's law
-
-Active and reactive power flows on branch ``e \in \mathcal{E}``
-    are obtained via Ohm's law as follows
-```math
-\begin{align*}
-g^{ff}_{e} \mathbf{v}_{i}^{2}
-    + g^{ft}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \cos (\Delta \theta_{e})
-    + b^{ft}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \sin (\Delta \theta_{e})
-    - \mathbf{p}^{\text{f}}_{e} &= 0\\
--b^{ff}_{e} \mathbf{v}_{i}^{2}
-    - b^{ft}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \cos (\Delta \theta_{e})
-    + g^{ft}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \sin (\Delta \theta_{e})
-    - \mathbf{q}^{\text{f}}_{e} &= 0\\
-g^{tt}_{e} \mathbf{v}_{j}^{2}
-    + g^{tf}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \cos (\Delta \theta_{e})
-    - b^{tf}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \sin (\Delta \theta_{e})
-    - \mathbf{p}^{\text{t}}_{e} &= 0\\
--b^{tt}_{e} \mathbf{v}_{j}^{2}
-    - b^{tf}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \cos (\Delta \theta_{e})
-    - g^{tf}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \sin (\Delta \theta_{e})
-    - \mathbf{q}^{\text{t}}_{e} &= 0
-\end{align*}
-```
-where ``\Delta \theta_{e} = \theta_{i} - \theta_{j}`` and branch ``e`` is from bus ``i`` to bus ``j``.
-
-### Thermal limits
-
-### Voltage angle difference limits
-
-### Variable bounds
-
-**Nodal voltage magnitude**
-```math
-\underline{v}_{i} \leq \mathbf{v}_{i} \leq \bar{v}_{i}, \quad \forall i \in \mathcal{N}
-```
-
-* Active/reactive power dispatch
-```math
-\underline{p}^{g}_{i} \leq \mathbf{p}^{\text{g}}_{i} \leq \bar{p}^{g}_{i}, \quad \forall i \in \mathcal{G}\\
-\underline{q}^{g}_{i} \leq p^{q}_{i} \leq \bar{q    }^{g}_{i}, \quad \forall i \in \mathcal{G}
-```
-  Minimum and/or maximum limits for active/reactive power dispatch may take negative values.
-
-* Bounds on power flows are derived from thermal limits
-```math
--S_{e} \leq \mathbf{p}^{\text{f}}_{e}, \mathbf{q}^{\text{f}}_{e}, \mathbf{p}^{\text{t}}_{e}, \mathbf{q}^{\text{t}}_{e} \leq S_{e}, \quad \forall e \in \mathcal{E}
-```
+* ``\eqref{eq:ACOPF:slack}``: this constraint fixes the voltage angle of the 
+    reference (slack) bus to zero.
+* ``\eqref{eq:ACOPF:kcl_p}-\eqref{eq:ACOPF:kcl_q}``:
+    active and reactive Kirchhoff's current law.
+* ``\eqref{eq:ACOPF:ohm_pf}-\eqref{eq:ACOPF:ohm_qt}``:
+    Ohm's law expressing power flows as a function of nodal voltages.
+* ``\eqref{eq:ACOPF:sm_f}-\eqref{eq:ACOPF:sm_t}``: Thermal limits
+* ``\eqref{eq:ACOPF:va_diff}``: Voltage angle deviation constraints.
+* ``\eqref{eq:ACOPF:vm_bounds}``: Nodal voltage angle limits
+* ``\eqref{eq:ACOPF:pg_bounds}-\eqref{eq:ACOPF:qg_bounds}``: Active/reactive generation limits
+* ``\eqref{eq:ACOPF:pf_bounds}-\eqref{eq:ACOPF:qt_bounds}``: Power flow bounds, derived from thermal limits
 
 !!! info
-    Although these lower/upper bounds on active/reactive power flows
-     are redundant with thermal constraints, their presence improves the performance
-    of interior-point solvers like Ipopt.
+    Although power flow variable bounds``\eqref{eq:ACOPF:pf_bounds}-\eqref{eq:ACOPF:qt_bounds}``
+    are redundant with thermal limits ``\eqref{eq:ACOPF:sm_f}-\eqref{eq:ACOPF:sm_t}``, 
+    their inclusion improves the performance of interior-point solvers like Ipopt.
+
 
 ## Data format
 
+### Primal solution
 
+| Variable                  | Data | Size  | Description 
+|:--------------------------|:-----|:------|:----------------------------------|
+| ``\mathbf{v}``            | `vm` | ``N`` | Nodal voltage magnitude
+| ``\boldsymbol{\theta}``   | `va` | ``N`` | Nodal voltage angle
+| ``\mathbf{p}^{\text{g}}`` | `pg` | ``G`` | Active power generation
+| ``\mathbf{q}^{\text{g}}`` | `pg` | ``G`` | Reactive power generation
+| ``\mathbf{p}^{\text{f}}`` | `pf` | ``E`` | Active power flow (from)
+| ``\mathbf{p}^{\text{t}}`` | `pt` | ``E`` | Active power flow (to)
+| ``\mathbf{q}^{\text{f}}`` | `qf` | ``E`` | Reactive power flow (from)
+| ``\mathbf{q}^{\text{t}}`` | `qt` | ``E`` | Reactive power flow (to)
 
+### Dual solution
+
+| Constraint                     | Data | Size  | Domain 
+|:-------------------------------|:-----|:------|:----------------------------------|
+| ``\eqref{eq:ACOPF:slack}``     | `slack_bus`  | ``N`` | Nodal voltage magnitude
+| ``\eqref{eq:ACOPF:kcl_p}``     | `kcl_p`      | ``N`` | Nodal voltage angle
+| ``\eqref{eq:ACOPF:kcl_q}``     | `kcl_q`      | ``N`` | Active power generation
+| ``\eqref{eq:ACOPF:ohm_pf}``    | `ohm_pf`     | ``E`` | Reactive power generation
+| ``\eqref{eq:ACOPF:ohm_qf}``    | `ohm_qf` | ``E`` | Active power flow (to)
+| ``\eqref{eq:ACOPF:ohm_pt}``    | `ohm_pt` | ``E`` | Active power flow (from)
+| ``\eqref{eq:ACOPF:ohm_qt}``    | `ohm_qt` | ``E`` | Reactive power flow (from)
+| ``\eqref{eq:ACOPF:sm_f}``      | `sm_fr` | ``E`` | Reactive power flow (to)
+| ``\eqref{eq:ACOPF:sm_t}``      | `sm_to` | ``E`` | Reactive power flow (to)
+| ``\eqref{eq:ACOPF:va_diff}``   | `va_diff` | ``E`` | Reactive power flow (to)
+| ``\eqref{eq:ACOPF:vm_bounds}`` (lower) | `vm_lb` | ``N`` | Voltage magnitude lower bounds
+| ``\eqref{eq:ACOPF:vm_bounds}`` (upper) | `vm_ub` | ``N`` | Voltage magnitude upper bounds
+| ``\eqref{eq:ACOPF:pg_bounds}`` (lower) | `pg_lb` | ``G`` | Active power generation lower bound
+| ``\eqref{eq:ACOPF:pg_bounds}`` (upper) | `pg_ub` | ``G`` | Active power generation upper bound
+| ``\eqref{eq:ACOPF:qg_bounds}`` (lower) | `qg_lb` | ``G`` | Reactive power generation lower bound
+| ``\eqref{eq:ACOPF:qg_bounds}`` (upper) | `qg_ub` | ``G`` | Reactive power generation upper bound
+| ``\eqref{eq:ACOPF:pf_bounds}`` (lower) | `pf_lb` | ``E`` | Active power flow (from) lower bound
+| ``\eqref{eq:ACOPF:pf_bounds}`` (upper) | `pf_ub` | ``E`` | Active power flow (from) upper bound
+| ``\eqref{eq:ACOPF:pf_bounds}`` (lower) | `qf_lb` | ``E`` | Reactive power flow (from) lower bound
+| ``\eqref{eq:ACOPF:pf_bounds}`` (upper) | `qf_ub` | ``E`` | Reactive power flow (from) upper bound
+| ``\eqref{eq:ACOPF:pf_bounds}`` (lower) | `pt_lb` | ``E`` | Active power flow (to) lower bound
+| ``\eqref{eq:ACOPF:pf_bounds}`` (upper) | `pt_ub` | ``E`` | Active power flow (to) upper bound
+| ``\eqref{eq:ACOPF:pf_bounds}`` (lower) | `qt_lb` | ``E`` | Reactive power flow (to) lower bound
+| ``\eqref{eq:ACOPF:pf_bounds}`` (upper) | `qt_ub` | ``E`` | Reactive power flow (to) upper bound

--- a/docs/src/opf/acp.md
+++ b/docs/src/opf/acp.md
@@ -85,7 +85,7 @@ The ACOPF model considered in OPFGenerator is presented below.
         && \forall i \in \mathcal{G}
         && [\mu^{pg}]\\
     & \label{eq:ACOPF:qg_bounds}
-        \underline{q}^{g}_{i} \leq p^{q}_{i} \leq \bar{q}^{g}_{i},
+        \underline{q}^{g}_{i} \leq \mathbf{q}^{\text{g}}_{i} \leq \bar{q}^{g}_{i},
         && \forall i \in \mathcal{G}
         && [\mu^{qg}]\\
     & \label{eq:ACOPF:pf_bounds}

--- a/docs/src/opf/acp.md
+++ b/docs/src/opf/acp.md
@@ -8,7 +8,7 @@ The ACOPF model considered in OPFGenerator is presented below.
 ```math
 \begin{align}
     \min_{\PG, \QG, \PF, \QF, \PT, \QT, \VM, \VA} \quad
-    & \sum_{i \in \NODES} \sum_{j \in \GENERATORS_{i}} c_j \PG_j \label{model:acopf:obj} \\
+    & \sum_{i \in \NODES} \sum_{j \in \GENERATORS_{i}} c_j \PG_j + c_0 \label{model:acopf:obj} \\
     \text{s.t.} \quad \quad \quad
     & \sum_{j\in\GENERATORS_i}\PG_j - \sum_{j\in\LOADS_i}\PD_j - \GS_i \VM_i^2 = \sum_{e \in \mathcal{E}_{i}}  \PF_{e} + \sum_{e \in \mathcal{E}^R_{i}} \PT_{e}
         & \forall i &\in \NODES

--- a/docs/src/opf/acp.md
+++ b/docs/src/opf/acp.md
@@ -28,10 +28,10 @@ The ACOPF model considered in OPFGenerator is presented below.
     & \QT_{e} = -\btt_{e} \VM_j^2 - \btf_{e}\VM_i \VM_j \cos(\VA_i-\VA_j) - \gtf_{e} \VM_i \VM_j \sin(\VA_i-\VA_j)
         & \forall e = (i,j) &\in \EDGES
         \label{model:acopf:ohm:reactive:to} \\
-    & (\PF_{e})^2 + (\QF_{e})^2 \leq \overline{S_{e}}^2
+    & (\PF_{e})^2 + (\QF_{e})^2 \leq \overline{S}_{e}^2
         & \forall e &\in \EDGES
         \label{model:acopf:thrmbound:from} \\
-    & (\PT_{e})^2 + (\QT_{e})^2 \leq \overline{S_{e}}^2
+    & (\PT_{e})^2 + (\QT_{e})^2 \leq \overline{S}_{e}^2
         & \forall e &\in \EDGES
         \label{model:acopf:thrmbound:to} \\
     & \dvamin_{e} \leq \VA_i - \VA_j \leq \dvamax_{e}

--- a/docs/src/opf/acp.md
+++ b/docs/src/opf/acp.md
@@ -1,3 +1,188 @@
 # AC-OPF
 
-See [`ACPPowerModel`](https://lanl-ansi.github.io/PowerModels.jl/stable/formulation-details/#PowerModels.ACPPowerModel) formulation in [`PowerModels.jl`](https://lanl-ansi.github.io/PowerModels.jl/stable/).
+The ACOPF model considered in OPFGenerator is presented below.
+
+```math
+\begin{align}
+    \min \quad 
+    & \sum_{g \in \mathcal{G}} c_{g} \mathbf{p}^{\text{g}}_{g} + c^{0}_{g}\\
+    \text{s.t.} \quad
+    & \theta_{i_{s}} = 0\\
+    & \sum_{g \in \mathcal{G}_{i}} \mathbf{p}^{\text{g}}_{g}
+        - \sum_{e \in \mathcal{E}^{+}_{i}} \mathbf{p}^{\text{f}}_{e}
+        - \sum_{e \in \mathcal{E}^{-}_{i}} \mathbf{p}^{\text{t}}_{e}
+        - g^{s}_{i} \mathbf{v}_{i}^{2}
+        =
+        \sum_{l \in \mathcal{L}_{i}} p^{d}_{l}
+        & \forall i \in \mathcal{N}
+        &&& [\lambda^{p}]\\
+    & \sum_{g \in \mathcal{G}_{i}} \mathbf{q}^{\text{g}}_{g}
+        - \sum_{e \in \mathcal{E}^{+}_{i}} \mathbf{q}^{\text{f}}_{e}
+        - \sum_{e \in \mathcal{E}^{-}_{i}} \mathbf{q}^{\text{t}}_{e}
+        + b^{s}_{i} \mathbf{v}_{i}^{2}
+        =
+        \sum_{l \in \mathcal{L}_{i}} q^{d}_{l}
+        & \forall i \in \mathcal{N}
+        &&& [\lambda^{q}]\\
+    % Ohm's law
+    & g^{ff}_{e} \mathbf{v}_{i}^{2}
+        + g^{ft}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \cos (\Delta \theta_{e})
+        + b^{ft}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \sin (\Delta \theta_{e})
+        - \mathbf{p}^{\text{f}}_{e} = 0
+        & \forall e \in \mathcal{E}
+        &&& [\lambda^{pf}]\\
+    & -b^{ff}_{e} \mathbf{v}_{i}^{2}
+        - b^{ft}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \cos (\Delta \theta_{e})
+        + g^{ft}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \sin (\Delta \theta_{e})
+        - \mathbf{q}^{\text{f}}_{e} = 0
+        & \forall e \in \mathcal{E}
+        &&& [\lambda^{qf}]\\
+    & g^{tt}_{e} \mathbf{v}_{j}^{2}
+        + g^{tf}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \cos (\Delta \theta_{e})
+        - b^{tf}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \sin (\Delta \theta_{e})
+        - \mathbf{p}^{\text{t}}_{e} = 0
+        & \forall e \in \mathcal{E}
+        &&& [\lambda^{pt}]\\
+    & -b^{tt}_{e} \mathbf{v}_{j}^{2}
+        - b^{tf}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \cos (\Delta \theta_{e})
+        - g^{tf}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \sin (\Delta \theta_{e})
+        - \mathbf{q}^{\text{t}}_{e} = 0
+        & \forall e \in \mathcal{E}
+        &&& [\lambda^{qt}]\\
+    % Thermal limits
+    & (\mathbf{p}^{\text{f}}_{e})^{2} + (\mathbf{q}^{\text{f}}_{e})^{2} \leq \bar{s}_{e}^{2}
+        & \forall e \in \mathcal{E}
+        &&& [\nu^{f}]\\
+    & (\mathbf{p}^{\text{t}}_{e})^{2} + (\mathbf{q}^{\text{t}}_{e})^{2} \leq \bar{s}_{e}^{2}
+        & \forall e \in \mathcal{E}
+        &&& [\nu^{t}]\\
+    % Voltage angle deviation
+    & \underline{\Delta} \theta_{e} \leq \Delta \theta_{e}
+        \leq \bar{\Delta} \theta_{e}
+        & \forall e \in \mathcal{E}
+        &&& [\mu^{\Delta \theta}]\\
+    % Variable bounds
+    & \underline{v}_{i} \leq \mathbf{v}_{i} \leq \bar{v}_{i}, 
+        & \forall i \in \mathcal{N}
+        &&& [\mu^{v}]\\ 
+    & \underline{p}^{g}_{i} \leq \mathbf{p}^{\text{g}}_{i} \leq \bar{p}^{g}_{i}, 
+        & \forall i \in \mathcal{G}
+        &&& [\mu^{pg}]\\
+    & \underline{q}^{g}_{i} \leq p^{q}_{i} \leq \bar{q}^{g}_{i},
+        & \forall i \in \mathcal{G}
+        &&& [\mu^{qg}]\\
+    & -\bar{s}_{e} \leq \mathbf{p}^{\text{f}}_{e}, \mathbf{q}^{\text{f}}_{e}, \mathbf{p}^{\text{t}}_{e}, \mathbf{q}^{\text{t}}_{e} \leq \bar{s}_{e}
+        & \forall e \in \mathcal{E}
+        &&& [\mu^{pf,qf,pt,qt}]
+\end{align}
+```
+where ``\Delta \theta_{e} = \theta_{i} - \theta_{j}`` for branch ``e = (i, j) \in \mathcal{E}``.
+
+
+## Variables
+
+* ``v \in \mathbb{R}^{N}``: nodal voltage magnitude
+* ``\theta \in \mathbb{R}^{N}``: nodal voltage angle
+* ``\mathbf{p}^{\text{g}} \in \mathbb{R}^{G}``: active power dispatch
+* ``\mathbf{q}^{\text{g}} \in \mathbb{R}^{G}``: reactive power dispatch
+* ``\mathbf{p}^{\text{f}} \in \mathbb{R}^{E}``: active power flow "from"
+* ``\mathbf{q}^{\text{f}} \in \mathbb{R}^{E}``: reactive power flow "from"
+* ``\mathbf{p}^{\text{t}} \in \mathbb{R}^{E}``: active power flow "to"
+* ``\mathbf{q}^{\text{t}} \in \mathbb{R}^{E}``: reactive power flow "to"
+
+## Objective
+
+The objective function minimizes the cost of active power generation.
+OPFGenerator currently supports only linear cost functions.
+
+## Constraints
+
+
+### Slack bus reference angle
+
+The slack bus reference angle constraint sets the voltage angle to zero at the slack bus.
+```math
+\theta_{i_{s}} = 0
+```
+where ``i_{s}`` is the index of the slack bus.
+
+### Kirchhoff current law
+
+Kirchhoff's current law (also known as "nodal power balance") for bus ``i \in \mathcal{N}``
+reads, for active power
+```math
+\sum_{g \in \mathcal{G}_{i}} \mathbf{p}^{\text{g}}_{g}
+- \sum_{e \in \mathcal{E}^{+}_{i}} \mathbf{p}^{\text{f}}_{e}
+- \sum_{e \in \mathcal{E}^{-}_{i}} \mathbf{p}^{\text{t}}_{e}
+- g^{s}_{i} \mathbf{v}_{i}^{2}
+=
+\sum_{l \in \mathcal{L}_{i}} p^{d}_{l}
+```
+and for reactive power
+```math
+\sum_{g \in \mathcal{G}_{i}} \mathbf{q}^{\text{g}}_{g}
+- \sum_{e \in \mathcal{E}^{+}_{i}} \mathbf{q}^{\text{f}}_{e}
+- \sum_{e \in \mathcal{E}^{-}_{i}} \mathbf{q}^{\text{t}}_{e}
++ b^{s}_{i} \mathbf{v}_{i}^{2}
+=
+\sum_{l \in \mathcal{L}_{i}} q^{d}_{l}
+```
+
+### Ohm's law
+
+Active and reactive power flows on branch ``e \in \mathcal{E}``
+    are obtained via Ohm's law as follows
+```math
+\begin{align*}
+g^{ff}_{e} \mathbf{v}_{i}^{2}
+    + g^{ft}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \cos (\Delta \theta_{e})
+    + b^{ft}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \sin (\Delta \theta_{e})
+    - \mathbf{p}^{\text{f}}_{e} &= 0\\
+-b^{ff}_{e} \mathbf{v}_{i}^{2}
+    - b^{ft}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \cos (\Delta \theta_{e})
+    + g^{ft}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \sin (\Delta \theta_{e})
+    - \mathbf{q}^{\text{f}}_{e} &= 0\\
+g^{tt}_{e} \mathbf{v}_{j}^{2}
+    + g^{tf}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \cos (\Delta \theta_{e})
+    - b^{tf}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \sin (\Delta \theta_{e})
+    - \mathbf{p}^{\text{t}}_{e} &= 0\\
+-b^{tt}_{e} \mathbf{v}_{j}^{2}
+    - b^{tf}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \cos (\Delta \theta_{e})
+    - g^{tf}_{e} \mathbf{v}_{i} \mathbf{v}_{j} \sin (\Delta \theta_{e})
+    - \mathbf{q}^{\text{t}}_{e} &= 0
+\end{align*}
+```
+where ``\Delta \theta_{e} = \theta_{i} - \theta_{j}`` and branch ``e`` is from bus ``i`` to bus ``j``.
+
+### Thermal limits
+
+### Voltage angle difference limits
+
+### Variable bounds
+
+**Nodal voltage magnitude**
+```math
+\underline{v}_{i} \leq \mathbf{v}_{i} \leq \bar{v}_{i}, \quad \forall i \in \mathcal{N}
+```
+
+* Active/reactive power dispatch
+```math
+\underline{p}^{g}_{i} \leq \mathbf{p}^{\text{g}}_{i} \leq \bar{p}^{g}_{i}, \quad \forall i \in \mathcal{G}\\
+\underline{q}^{g}_{i} \leq p^{q}_{i} \leq \bar{q    }^{g}_{i}, \quad \forall i \in \mathcal{G}
+```
+  Minimum and/or maximum limits for active/reactive power dispatch may take negative values.
+
+* Bounds on power flows are derived from thermal limits
+```math
+-S_{e} \leq \mathbf{p}^{\text{f}}_{e}, \mathbf{q}^{\text{f}}_{e}, \mathbf{p}^{\text{t}}_{e}, \mathbf{q}^{\text{t}}_{e} \leq S_{e}, \quad \forall e \in \mathcal{E}
+```
+
+!!! info
+    Although these lower/upper bounds on active/reactive power flows
+     are redundant with thermal constraints, their presence improves the performance
+    of interior-point solvers like Ipopt.
+
+## Data format
+
+
+

--- a/docs/src/opf/dcp.md
+++ b/docs/src/opf/dcp.md
@@ -1,8 +1,8 @@
 # DC-OPF
 
-## Mathematical formulation
+## Mathematical Formulation
 
-The primal problem reads
+The DCOPF model considered in OPFGenerator is presented below.
 
 ```math
 \begin{align}
@@ -29,7 +29,34 @@ The primal problem reads
 \end{align}
 ```
 
-## Nomenclature
+
+### Variables
+
+* ``\PG \in \mathbb{R}^{G}``: active power dispatch
+* ``\PF \in \mathbb{R}^{E}``: active power flow "from"
+* ``\VA \in \mathbb{R}^{N}``: nodal voltage angle
+
+### Objective
+
+The objective function ``\eqref{model:dcopf:obj}`` minimizes the cost of active power generation.
+
+!!! todo
+    OPFGenerator currently supports only linear cost functions.
+    Support for quadratic functions is planned for a later stage; please open an issue if 
+    you would like to request this feature.
+
+### Constraints
+
+* ``\eqref{model:dcopf:kirchhoff}``: Kirchhoff's current law.
+* ``\eqref{model:dcopf:ohm}``: Ohm's law expressing power flows as a function of nodal voltages.
+* ``\eqref{model:dcopf:thrmbound:from}``: Thermal limits.
+* ``\eqref{model:dcopf:angledifference}``: Voltage angle deviation constraints.
+* ``\eqref{model:dcopf:slackbus}``: this constraint fixes the voltage angle of the reference (slack) bus to zero.
+* ``\eqref{model:dcopf:pgbound}``: Active generation limits.
+
+
+
+## Data Format
 
 ### Primal variables
 

--- a/docs/src/opf/dcp.md
+++ b/docs/src/opf/dcp.md
@@ -20,10 +20,10 @@ The DCOPF model considered in OPFGenerator is presented below.
         & \forall e = (i, j) &\in \EDGES
     \label{model:dcopf:angledifference} \\
     & \VA_\text{ref} = 0 \label{model:dcopf:slackbus} \\
-    & \underline{\PG_i} \leq \PG_i \leq \overline{\PG_i}
+    & \pgmin_{i} \leq \PG_i \leq \pgmax_{i}
         & \forall i &\in \GENERATORS
     \label{model:dcopf:pgbound} \\
-    & {-}\overline{S_{e}} \leq  \PF_{e} \leq \overline{S_{e}}
+    & {-}\overline{S}_{e} \leq  \PF_{e} \leq \overline{S}_{e}
         & \forall e &\in \EDGES
     \label{model:dcopf:thrmbound:from}
 \end{align}

--- a/docs/src/opf/dcp.md
+++ b/docs/src/opf/dcp.md
@@ -9,7 +9,7 @@ The DCOPF model considered in OPFGenerator is presented below.
     \min_{\PG, \PF, \VA} &\quad
         \sum_{i \in \NODES} \sum_{j \in \GENERATORS_{i}} c_j \PG_j + c_0 \label{model:dcopf:obj} \\
     \text{s.t.} \quad
-    & \sum_{j\in\GENERATORS_i}\PG_j - \sum_{e \in \mathcal{E}_{i}}  \PF_{e} + \sum_{e \in \mathcal{E}^R_{i}} \PF_{e}
+    & \sum_{j\in\GENERATORS_i}\PG_j - \sum_{e \in \mathcal{E}^{+}_{i}}  \PF_{e} + \sum_{e \in \mathcal{E}^{-}_{i}} \PF_{e}
     = \sum_{j\in\LOADS_i}\PD_j + \GS_i 
         & \forall i &\in \NODES
     \label{model:dcopf:kirchhoff} \\

--- a/docs/src/opf/dcp.md
+++ b/docs/src/opf/dcp.md
@@ -7,7 +7,7 @@ The DCOPF model considered in OPFGenerator is presented below.
 ```math
 \begin{align}
     \min_{\PG, \PF, \VA} &\quad
-        \sum_{i \in \NODES} \sum_{j \in \GENERATORS_{i}} c_j \PG_j \label{model:dcopf:obj} \\
+        \sum_{i \in \NODES} \sum_{j \in \GENERATORS_{i}} c_j \PG_j + c_0 \label{model:dcopf:obj} \\
     \text{s.t.} \quad
     & \sum_{j\in\GENERATORS_i}\PG_j - \sum_{e \in \mathcal{E}_{i}}  \PF_{e} + \sum_{e \in \mathcal{E}^R_{i}} \PF_{e}
     = \sum_{j\in\LOADS_i}\PD_j + \GS_i 


### PR DESCRIPTION
This branch continues from `mt/ac-docs`:

- Switch to `MathJax3` (`MathJax` is deprecated)
- Utility functions for reusing our `definitions.tex` file
- Slightly widened the `docs-main` div so the labels fit
- Updated AC docs
- Updated DC docs

Note this version doesn't have the corresponding dual next to each constraint / in the data table.

https://ai4opt.github.io/OPFGenerator/previews/PR153/opf/acp/