### PR TITLE
Red links for legibility in dark mode

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,7 +8,7 @@ makedocs(
     modules=[OPFGenerator],
     sitename = "OPFGenerator",
     format = Documenter.HTML(;
-        assets = ["assets/wider.css"],
+        assets = ["assets/wider.css", "assets/redlinks.css"],
         mathengine = Documenter.MathJax3(Dict(
             :tex => Dict(
                 "macros" => make_macros_dict("docs/src/assets/definitions.tex"),

--- a/docs/src/assets/redlinks.css
+++ b/docs/src/assets/redlinks.css
@@ -1,0 +1,4 @@
+mjx-container[jax="SVG"] > svg a {
+    fill: red !important; /* default is blue */
+    stroke: red !important; /* default is blue */
+}


### PR DESCRIPTION
The Mathjax default "SVG" renderer overrides the link color to `blue`, which is hard to read when in dark mode:
<img width="532" alt="Screenshot 2025-01-09 at 4 39 22 PM" src="https://github.com/user-attachments/assets/2db1ff0d-92d3-437c-8909-342ae9454bb4" />


This PR changes the link color to `red`, which is easier to read:
<img width="537" alt="Screenshot 2025-01-09 at 4 38 45 PM" src="https://github.com/user-attachments/assets/47c440ed-06d4-4102-bd04-749349e33695" />

ref https://github.com/mathjax/MathJax/issues/2485

 https://ai4opt.github.io/OPFGenerator/previews/PR160