### PR TITLE
Merge duals of lower/upper bound constraints

### DIFF
--- a/docs/src/opf/acp.md
+++ b/docs/src/opf/acp.md
@@ -133,17 +133,10 @@ The objective function ``\eqref{model:acopf:obj}`` minimizes the cost of active 
 | ``\eqref{model:acopf:thrmbound:to}``         | `sm_to`      | ``E`` |
 | ``\eqref{model:acopf:angledifference}``      | `va_diff`    | ``E`` |
 | ``\eqref{model:acopf:slackbus}``             | `slack_bus`  | ``N`` |
-| ``\eqref{model:acopf:pgbound}`` (lower)      | `pg_lb`      | ``G`` |
-| ``\eqref{model:acopf:pgbound}`` (upper)      | `pg_ub`      | ``G`` |
-| ``\eqref{model:acopf:qgbound}`` (lower)      | `qg_lb`      | ``G`` |
-| ``\eqref{model:acopf:qgbound}`` (upper)      | `qg_ub`      | ``G`` |
-| ``\eqref{model:acopf:vmbound}`` (lower)      | `vm_lb`      | ``N`` |
-| ``\eqref{model:acopf:vmbound}`` (upper)      | `vm_ub`      | ``N`` |
-| ``\eqref{model:acopf:pfbound}`` (lower)      | `pf_lb`      | ``E`` |
-| ``\eqref{model:acopf:pfbound}`` (upper)      | `pf_ub`      | ``E`` |
-| ``\eqref{model:acopf:qfbound}`` (lower)      | `qf_lb`      | ``E`` |
-| ``\eqref{model:acopf:qfbound}`` (upper)      | `qf_ub`      | ``E`` |
-| ``\eqref{model:acopf:ptbound}`` (lower)      | `pt_lb`      | ``E`` |
-| ``\eqref{model:acopf:ptbound}`` (upper)      | `pt_ub`      | ``E`` |
-| ``\eqref{model:acopf:qtbound}`` (lower)      | `qt_lb`      | ``E`` |
-| ``\eqref{model:acopf:qtbound}`` (upper)      | `qt_ub`      | ``E`` |
+| ``\eqref{model:acopf:pgbound}``              | `pg`         | ``G`` |
+| ``\eqref{model:acopf:qgbound}``              | `qg`         | ``G`` |
+| ``\eqref{model:acopf:vmbound}``              | `vm`         | ``N`` |
+| ``\eqref{model:acopf:pfbound}``              | `pf`         | ``E`` |
+| ``\eqref{model:acopf:qfbound}``              | `qf`         | ``E`` |
+| ``\eqref{model:acopf:ptbound}``              | `pt`         | ``E`` |
+| ``\eqref{model:acopf:qtbound}``              | `qt`         | ``E`` |

--- a/docs/src/opf/dcp.md
+++ b/docs/src/opf/dcp.md
@@ -74,7 +74,5 @@ The objective function ``\eqref{model:dcopf:obj}`` minimizes the cost of active 
 | ``\eqref{model:dcopf:kirchhoff}``                 | `kcl_p`      | ``N`` |
 | ``\eqref{model:dcopf:ohm}``                       | `ohm`        | ``E`` |
 | ``\eqref{model:dcopf:angledifference}``           | `va_diff`    | ``E`` |
-| ``\eqref{model:dcopf:pgbound}`` (lower)           | `pg_min`     | ``G`` |
-| ``\eqref{model:dcopf:pgbound}`` (upper)           | `pg_max`     | ``G`` |
-| ``\eqref{model:dcopf:thrmbound:from}`` (lower)    | `pf_min`     | ``E`` |
-| ``\eqref{model:dcopf:thrmbound:from}`` (upper)    | `pf_max`     | ``E`` |
+| ``\eqref{model:dcopf:pgbound}``                   | `pg`         | ``G`` |
+| ``\eqref{model:dcopf:thrmbound:from}``            | `pf`         | ``E`` |

--- a/docs/src/opf/socwr.md
+++ b/docs/src/opf/socwr.md
@@ -261,21 +261,12 @@ The objective function ``\eqref{eq:SOCOPF:objective}`` minimizes the cost of act
 | ``\eqref{eq:SOCOPF:sm_f}``              | `sm_fr`      | ``E \times 3`` |
 | ``\eqref{eq:SOCOPF:sm_t}``              | `sm_to`      | ``E \times 3`` |
 | ``\eqref{eq:SOCOPF:va_diff}``           | `va_diff`    | ``E``          |
-| ``\eqref{eq:SOCOPF:pg_bounds}`` (lower) | `pg_lb`      | ``G``          |
-| ``\eqref{eq:SOCOPF:pg_bounds}`` (upper) | `pg_ub`      | ``G``          | 
-| ``\eqref{eq:SOCOPF:qg_bounds}`` (lower) | `qg_lb`      | ``G``          | 
-| ``\eqref{eq:SOCOPF:qg_bounds}`` (upper) | `qg_ub`      | ``G``          |
-| ``\eqref{eq:SOCOPF:wm_bounds}`` (lower) | `w_lb`       | ``N``          |
-| ``\eqref{eq:SOCOPF:wm_bounds}`` (upper) | `w_ub`       | ``N``          |
-| ``\eqref{eq:SOCOPF:wr_bounds}`` (lower) | `wr_lb`      | ``E``          |
-| ``\eqref{eq:SOCOPF:wr_bounds}`` (upper) | `wr_ub`      | ``E``          |
-| ``\eqref{eq:SOCOPF:wi_bounds}`` (lower) | `wi_lb`      | ``E``          |
-| ``\eqref{eq:SOCOPF:wi_bounds}`` (upper) | `wi_ub`      | ``E``          |
-| ``\eqref{eq:SOCOPF:pf_bounds}`` (lower) | `pf_lb`      | ``E``          |
-| ``\eqref{eq:SOCOPF:pf_bounds}`` (upper) | `pf_ub`      | ``E``          |
-| ``\eqref{eq:SOCOPF:qf_bounds}`` (lower) | `qf_lb`      | ``E``          |
-| ``\eqref{eq:SOCOPF:qf_bounds}`` (upper) | `qf_ub`      | ``E``          |
-| ``\eqref{eq:SOCOPF:pt_bounds}`` (lower) | `pt_lb`      | ``E``          |
-| ``\eqref{eq:SOCOPF:pt_bounds}`` (upper) | `pt_ub`      | ``E``          |
-| ``\eqref{eq:SOCOPF:qt_bounds}`` (lower) | `qt_lb`      | ``E``          |
-| ``\eqref{eq:SOCOPF:qt_bounds}`` (upper) | `qt_ub`      | ``E``          |
+| ``\eqref{eq:SOCOPF:pg_bounds}``         | `pg`         | ``G``          |
+| ``\eqref{eq:SOCOPF:qg_bounds}``         | `qg`         | ``G``          | 
+| ``\eqref{eq:SOCOPF:wm_bounds}``         | `w`          | ``N``          |
+| ``\eqref{eq:SOCOPF:wr_bounds}``         | `wr`         | ``E``          |
+| ``\eqref{eq:SOCOPF:wi_bounds}``         | `wi`         | ``E``          |
+| ``\eqref{eq:SOCOPF:pf_bounds}``         | `pf`         | ``E``          |
+| ``\eqref{eq:SOCOPF:qf_bounds}``         | `qf`         | ``E``          |
+| ``\eqref{eq:SOCOPF:pt_bounds}``         | `pt`         | ``E``          |
+| ``\eqref{eq:SOCOPF:qt_bounds}``         | `qt`         | ``E``          |

--- a/src/opf/acp.jl
+++ b/src/opf/acp.jl
@@ -212,22 +212,15 @@ function extract_dual(opf::OPFModel{ACOPF})
         "va_diff"   => zeros(T, E),
         # variables lower/upper bounds
         # bus
-        "vm_lb"     => zeros(T, N),
-        "vm_ub"     => zeros(T, N),
+        "vm"        => zeros(T, N),
         # generator
-        "pg_lb"     => zeros(T, G),
-        "pg_ub"     => zeros(T, G),
-        "qg_lb"     => zeros(T, G),
-        "qg_ub"     => zeros(T, G),
+        "pg"        => zeros(T, G),
+        "qg"        => zeros(T, G),
         # branch
-        "pf_lb"      => zeros(T, E),
-        "pf_ub"      => zeros(T, E),
-        "qf_lb"      => zeros(T, E),
-        "qf_ub"      => zeros(T, E),
-        "pt_lb"      => zeros(T, E),
-        "pt_ub"      => zeros(T, E),
-        "qt_lb"      => zeros(T, E),
-        "qt_ub"      => zeros(T, E),
+        "pf"        => zeros(T, E),
+        "qf"        => zeros(T, E),
+        "pt"        => zeros(T, E),
+        "qt"        => zeros(T, E),
     )
 
     if has_duals(model)
@@ -251,23 +244,16 @@ function extract_dual(opf::OPFModel{ACOPF})
 
         # Variable lower/upper bounds
         # bus
-        dual_solution["vm_lb"] = dual.(LowerBoundRef.(model[:vm]))
-        dual_solution["vm_ub"] = dual.(UpperBoundRef.(model[:vm]))
+        dual_solution["vm"] = dual.(LowerBoundRef.(model[:vm])) + dual.(UpperBoundRef.(model[:vm]))
         #    (nodal voltage angles have no lower/upper bounds)
         # generator
-        dual_solution["pg_lb"] = dual.(LowerBoundRef.(model[:pg]))
-        dual_solution["pg_ub"] = dual.(UpperBoundRef.(model[:pg]))
-        dual_solution["qg_lb"] = dual.(LowerBoundRef.(model[:qg]))
-        dual_solution["qg_ub"] = dual.(UpperBoundRef.(model[:qg]))
+        dual_solution["pg"] = dual.(LowerBoundRef.(model[:pg])) + dual.(UpperBoundRef.(model[:pg]))
+        dual_solution["qg"] = dual.(LowerBoundRef.(model[:qg])) + dual.(UpperBoundRef.(model[:qg]))
         # branch
-        dual_solution["pf_lb"] = dual.(LowerBoundRef.(model[:pf]))
-        dual_solution["pf_ub"] = dual.(UpperBoundRef.(model[:pf]))
-        dual_solution["qf_lb"] = dual.(LowerBoundRef.(model[:qf]))
-        dual_solution["qf_ub"] = dual.(UpperBoundRef.(model[:qf]))
-        dual_solution["pt_lb"] = dual.(LowerBoundRef.(model[:pt]))
-        dual_solution["pt_ub"] = dual.(UpperBoundRef.(model[:pt]))
-        dual_solution["qt_lb"] = dual.(LowerBoundRef.(model[:qt]))
-        dual_solution["qt_ub"] = dual.(UpperBoundRef.(model[:qt]))
+        dual_solution["pf"] = dual.(LowerBoundRef.(model[:pf])) + dual.(UpperBoundRef.(model[:pf]))
+        dual_solution["qf"] = dual.(LowerBoundRef.(model[:qf])) + dual.(UpperBoundRef.(model[:qf]))
+        dual_solution["pt"] = dual.(LowerBoundRef.(model[:pt])) + dual.(UpperBoundRef.(model[:pt]))
+        dual_solution["qt"] = dual.(LowerBoundRef.(model[:qt])) + dual.(UpperBoundRef.(model[:qt]))
     end
 
     return dual_solution

--- a/src/opf/acp.jl
+++ b/src/opf/acp.jl
@@ -242,7 +242,12 @@ function extract_dual(opf::OPFModel{ACOPF})
         dual_solution["sm_to"] = dual.(model[:sm_to])
         dual_solution["va_diff"] = dual.(model[:va_diff])
 
-        # Variable lower/upper bounds
+        # Duals of variable lower/upper bounds
+        # We store λ = λₗ + λᵤ, where λₗ, λᵤ are the dual variables associated to
+        #   lower and upper bounds, respectively.
+        # Recall that, in JuMP's convention, we have λₗ ≥ 0, λᵤ ≤ 0, hence
+        #   λₗ = max(λ, 0) and λᵤ = min(λ, 0).
+
         # bus
         dual_solution["vm"] = dual.(LowerBoundRef.(model[:vm])) + dual.(UpperBoundRef.(model[:vm]))
         #    (nodal voltage angles have no lower/upper bounds)

--- a/src/opf/dcp.jl
+++ b/src/opf/dcp.jl
@@ -164,11 +164,9 @@ function extract_dual(opf::OPFModel{DCOPF})
 
         # (no bounded bus-level variables)
         # generator
-        dual_solution["pg"] .+= dual.(LowerBoundRef.(model[:pg]))
-        dual_solution["pg"] .+= dual.(UpperBoundRef.(model[:pg]))
+        dual_solution["pg"] = dual.(LowerBoundRef.(model[:pg])) + dual.(UpperBoundRef.(model[:pg]))
         # branch
-        dual_solution["pf"] .+= dual.(LowerBoundRef.(model[:pf]))
-        dual_solution["pf"] .+= dual.(UpperBoundRef.(model[:pf]))
+        dual_solution["pf"] = dual.(LowerBoundRef.(model[:pf])) + dual.(UpperBoundRef.(model[:pf]))
     end
 
     return dual_solution

--- a/src/opf/ed.jl
+++ b/src/opf/ed.jl
@@ -305,7 +305,11 @@ function extract_dual(opf::OPFModel{EconomicDispatch})
             for e in 1:E
         ]
 
-        # Variable lower/upper bound
+        # Duals of variable lower/upper bounds
+        # We store λ = λₗ + λᵤ, where λₗ, λᵤ are the dual variables associated to
+        #   lower and upper bounds, respectively.
+        # Recall that, in JuMP's convention, we have λₗ ≥ 0, λᵤ ≤ 0, hence
+        #   λₗ = max(λ, 0) and λᵤ = min(λ, 0).
         # generator
         dual_solution["pg"] = dual.(LowerBoundRef.(model[:pg])) + dual.(model[:gen_max_output])
         dual_solution["r"] = dual.(LowerBoundRef.(model[:r])) + dual.(UpperBoundRef.(model[:r]))

--- a/src/opf/ed.jl
+++ b/src/opf/ed.jl
@@ -286,13 +286,10 @@ function extract_dual(opf::OPFModel{EconomicDispatch})
         # branch
         "ptdf_flow" => zeros(T, E),
         # Variable lower/upper bound
-        "pg_lb"     => zeros(T, G),
-        "pg_ub"     => zeros(T, G),
-        "r_lb"      => zeros(T, G),
-        "r_ub"      => zeros(T, G),
-        "pf_lb"     => zeros(T, E),
-        "pf_ub"     => zeros(T, E),
-        "δf_lb"     => zeros(T, E),
+        "pg"     => zeros(T, G),
+        "r"      => zeros(T, G),
+        "pf"     => zeros(T, E),
+        "δf"     => zeros(T, E),
     )
 
 
@@ -310,14 +307,11 @@ function extract_dual(opf::OPFModel{EconomicDispatch})
 
         # Variable lower/upper bound
         # generator
-        dual_solution["pg_lb"] = dual.(LowerBoundRef.(model[:pg]))
-        dual_solution["pg_ub"] = dual.(model[:gen_max_output])
-        dual_solution["r_lb"] = dual.(LowerBoundRef.(model[:r]))
-        dual_solution["r_ub"] = dual.(UpperBoundRef.(model[:r]))
+        dual_solution["pg"] = dual.(LowerBoundRef.(model[:pg])) + dual.(model[:gen_max_output])
+        dual_solution["r"] = dual.(LowerBoundRef.(model[:r])) + dual.(UpperBoundRef.(model[:r]))
         # branch
-        dual_solution["pf_lb"] = dual.(model[:pf_lower_bound])
-        dual_solution["pf_ub"] = dual.(model[:pf_upper_bound])
-        dual_solution["δf_lb"] = dual.(LowerBoundRef.(model[:δf]))
+        dual_solution["pf"] = dual.(model[:pf_lower_bound]) + dual.(model[:pf_upper_bound])
+        dual_solution["δf"] = dual.(LowerBoundRef.(model[:δf]))
     end
 
     return dual_solution

--- a/src/opf/socwr.jl
+++ b/src/opf/socwr.jl
@@ -262,7 +262,7 @@ function extract_dual(opf::OPFModel{OPF}) where {OPF <: Union{SOCOPFQuad,SOCOPF}
         dual_solution["ohm_pt"] = dual.(model[:ohm_pt])
         dual_solution["ohm_qf"] = dual.(model[:ohm_qf])
         dual_solution["ohm_qt"] = dual.(model[:ohm_qt])
-        dual_solution["va_diff"] = dual.(model[:va_diff_lb]) + dual.(model[:va_diff_ub])  # ame as bound constraints
+        dual_solution["va_diff"] = dual.(model[:va_diff_lb]) + dual.(model[:va_diff_ub])  # same as bound constraints
         dual_solution["sm_fr"] = dual.(model[:sm_fr])
         dual_solution["sm_to"] = dual.(model[:sm_to])
         dual_solution["jabr"] = dual.(model[:jabr])

--- a/src/opf/socwr.jl
+++ b/src/opf/socwr.jl
@@ -223,30 +223,20 @@ function extract_dual(opf::OPFModel{OPF}) where {OPF <: Union{SOCOPFQuad,SOCOPF}
         "ohm_pt"     => zeros(T, E),
         "ohm_qf"     => zeros(T, E),
         "ohm_qt"     => zeros(T, E),
-        "va_diff_lb" => zeros(T, E),
-        "va_diff_ub" => zeros(T, E),
+        "va_diff"    => zeros(T, E),
         # variables lower/upper bounds
         # bus
-        "w_lb"       => zeros(T, N),
-        "w_ub"       => zeros(T, N),
+        "w"          => zeros(T, N),
         # generator
-        "pg_lb"      => zeros(T, G),
-        "pg_ub"      => zeros(T, G),
-        "qg_lb"      => zeros(T, G),
-        "qg_ub"      => zeros(T, G),
+        "pg"         => zeros(T, G),
+        "qg"         => zeros(T, G),
         # branch
-        "wr_lb"      => zeros(T, E),
-        "wr_ub"      => zeros(T, E),
-        "wi_lb"      => zeros(T, E),
-        "wi_ub"      => zeros(T, E),
-        "pf_lb"      => zeros(T, E),
-        "pf_ub"      => zeros(T, E),
-        "qf_lb"      => zeros(T, E),
-        "qf_ub"      => zeros(T, E),
-        "pt_lb"      => zeros(T, E),
-        "pt_ub"      => zeros(T, E),
-        "qt_lb"      => zeros(T, E),
-        "qt_ub"      => zeros(T, E),
+        "wr"         => zeros(T, E),
+        "wi"         => zeros(T, E),
+        "pf"         => zeros(T, E),
+        "qf"         => zeros(T, E),
+        "pt"         => zeros(T, E),
+        "qt"         => zeros(T, E),
     )
 
     if OPF == SOCOPFQuad
@@ -272,8 +262,7 @@ function extract_dual(opf::OPFModel{OPF}) where {OPF <: Union{SOCOPFQuad,SOCOPF}
         dual_solution["ohm_pt"] = dual.(model[:ohm_pt])
         dual_solution["ohm_qf"] = dual.(model[:ohm_qf])
         dual_solution["ohm_qt"] = dual.(model[:ohm_qt])
-        dual_solution["va_diff_lb"] = dual.(model[:va_diff_lb])
-        dual_solution["va_diff_ub"] = dual.(model[:va_diff_ub])
+        dual_solution["va_diff"] = dual.(model[:va_diff_lb]) + dual.(model[:va_diff_ub])  # ame as bound constraints
         dual_solution["sm_fr"] = dual.(model[:sm_fr])
         dual_solution["sm_to"] = dual.(model[:sm_to])
         dual_solution["jabr"] = dual.(model[:jabr])
@@ -287,27 +276,23 @@ function extract_dual(opf::OPFModel{OPF}) where {OPF <: Union{SOCOPFQuad,SOCOPF}
         end
 
         # Duals of variable lower/upper bounds
+        # We store λ = λₗ + λᵤ, where λₗ, λᵤ are the dual variables associated to
+        #   lower and upper bounds, respectively.
+        # Recall that, in JuMP's convention, we have λₗ ≥ 0, λᵤ ≤ 0, hence
+        #   λₗ = max(λ, 0) and λᵤ = min(λ, 0).
+
         # bus
-        dual_solution["w_lb"] = dual.(LowerBoundRef.(model[:w]))
-        dual_solution["w_ub"] = dual.(UpperBoundRef.(model[:w]))
+        dual_solution["w"]  = dual.(LowerBoundRef.(model[:w])) + dual.(UpperBoundRef.(model[:w]))
         # generator
-        dual_solution["pg_lb"] = dual.(LowerBoundRef.(model[:pg]))
-        dual_solution["pg_ub"] = dual.(UpperBoundRef.(model[:pg]))
-        dual_solution["qg_lb"] = dual.(LowerBoundRef.(model[:qg]))
-        dual_solution["qg_ub"] = dual.(UpperBoundRef.(model[:qg]))
+        dual_solution["pg"] = dual.(LowerBoundRef.(model[:pg])) + dual.(UpperBoundRef.(model[:pg]))
+        dual_solution["qg"] = dual.(LowerBoundRef.(model[:qg])) + dual.(UpperBoundRef.(model[:qg]))
         # branch
-        dual_solution["wr_lb"] = dual.(LowerBoundRef.(model[:wr]))
-        dual_solution["wr_ub"] = dual.(UpperBoundRef.(model[:wr]))
-        dual_solution["wi_lb"] = dual.(LowerBoundRef.(model[:wi]))
-        dual_solution["wi_ub"] = dual.(UpperBoundRef.(model[:wi]))
-        dual_solution["pf_lb"] = dual.(LowerBoundRef.(model[:pf]))
-        dual_solution["pf_ub"] = dual.(UpperBoundRef.(model[:pf]))
-        dual_solution["qf_lb"] = dual.(LowerBoundRef.(model[:qf]))
-        dual_solution["qf_ub"] = dual.(UpperBoundRef.(model[:qf]))
-        dual_solution["pt_lb"] = dual.(LowerBoundRef.(model[:pt]))
-        dual_solution["pt_ub"] = dual.(UpperBoundRef.(model[:pt]))
-        dual_solution["qt_lb"] = dual.(LowerBoundRef.(model[:qt]))
-        dual_solution["qt_ub"] = dual.(UpperBoundRef.(model[:qt]))
+        dual_solution["wr"] = dual.(LowerBoundRef.(model[:wr])) + dual.(UpperBoundRef.(model[:wr]))
+        dual_solution["wi"] = dual.(LowerBoundRef.(model[:wi])) + dual.(UpperBoundRef.(model[:wi]))
+        dual_solution["pf"] = dual.(LowerBoundRef.(model[:pf])) + dual.(UpperBoundRef.(model[:pf]))
+        dual_solution["qf"] = dual.(LowerBoundRef.(model[:qf])) + dual.(UpperBoundRef.(model[:qf]))
+        dual_solution["pt"] = dual.(LowerBoundRef.(model[:pt])) + dual.(UpperBoundRef.(model[:pt]))
+        dual_solution["qt"] = dual.(LowerBoundRef.(model[:qt])) + dual.(UpperBoundRef.(model[:qt]))
     end
 
     return dual_solution

--- a/test/opf/socwr.jl
+++ b/test/opf/socwr.jl
@@ -130,33 +130,24 @@ function _test_socwr_DualFeasibility(data, res; atol=1e-6)
     end
 
     # Check dual feasibility for select buses and constraints
-    λp  = [res["dual"]["kcl_p"][i] for i in 1:N]
-    λq  = [res["dual"]["kcl_q"][i] for i in 1:N]
-    λpf = [res["dual"]["ohm_pf"][e] for e in 1:E]
-    λqf = [res["dual"]["ohm_qf"][e] for e in 1:E]
-    λpt = [res["dual"]["ohm_pt"][e] for e in 1:E]
-    λqt = [res["dual"]["ohm_qt"][e] for e in 1:E]
+    λp  = res["dual"]["kcl_p"]
+    λq  = res["dual"]["kcl_q"]
+    λpf = res["dual"]["ohm_pf"]
+    λqf = res["dual"]["ohm_qf"]
+    λpt = res["dual"]["ohm_pt"]
+    λqt = res["dual"]["ohm_qt"]
 
-    ωf = [res["dual"]["jabr"][e, 1] for e in 1:E]
-    ωt = [res["dual"]["jabr"][e, 2] for e in 1:E]
-    ωr = [res["dual"]["jabr"][e, 3] for e in 1:E]
-    ωi = [res["dual"]["jabr"][e, 4] for e in 1:E]
+    ωf = res["dual"]["jabr"][:, 1]
+    ωt = res["dual"]["jabr"][:, 2]
+    ωr = res["dual"]["jabr"][:, 3]
+    ωi = res["dual"]["jabr"][:, 4]
 
-    μθ_lb = [res["dual"]["va_diff_lb"][e] for e in 1:E]
-    μθ_ub = [-res["dual"]["va_diff_ub"][e] for e in 1:E]
+    μθ_lb = max.(0, res["dual"]["va_diff"])
+    μθ_ub = min.(0, res["dual"]["va_diff"])
 
-    μ_w = [
-        res["dual"]["w_lb"][i] + res["dual"]["w_ub"][i]
-        for i in 1:N
-    ]
-    μ_wr = [
-        res["dual"]["wr_lb"][e] + res["dual"]["wr_ub"][e]
-        for e in 1:E
-    ]
-    μ_wi = [
-        res["dual"]["wi_lb"][e] + res["dual"]["wi_ub"][e]
-        for e in 1:E
-    ]
+    μ_w = res["dual"]["w"]
+    μ_wr = res["dual"]["wr"]
+    μ_wi = res["dual"]["wi"]
 
     # Check dual constraint corresponding to `w` variables
     δw = [


### PR DESCRIPTION
Merging dual variables associated to two-sided constraints, most typically showing up as lower/upper bound on primal variables.
This should reduce the size of datasets on disk (and in memory)