### PR TITLE
Do not re-export config in input.h5

### DIFF
--- a/exp/sampler.jl
+++ b/exp/sampler.jl
@@ -74,7 +74,6 @@ end
 
 function main(data, config)
     d = Dict{String,Any}()
-    d["config"] = deepcopy(config)
     
     # Keep track of input data
     d["data"] = data
@@ -126,19 +125,18 @@ if abspath(PROGRAM_FILE) == @__FILE__
     # These are concatenated at the end to create one H5 file per OPF configuration
     D = Dict{String,Any}()
     D["input"] = Dict{String,Any}(
-        "meta" => Dict{String,Any}("seed" => Int[]),
-        "data" => Dict{String,Any}(
-            "reserve_requirement" => Float64[],
-            # Demand data
-            "pd" => Vector{Float64}[],
-            "qd" => Vector{Float64}[],
-            # Generator reserves min/max levels
-            "rmin" => Vector{Float64}[],
-            "rmax" => Vector{Float64}[],
-            # Component status
-            "branch_status" => Vector{Bool}[],
-            "gen_status" => Vector{Bool}[],
-        )
+        "seed" => Int[],
+        # Demand data
+        "pd" => Vector{Float64}[],
+        "qd" => Vector{Float64}[],
+        # Global reserve requirement
+        "reserve_requirement" => Float64[],
+        # Generator reserves min/max levels
+        "rmin" => Vector{Float64}[],
+        "rmax" => Vector{Float64}[],
+        # Component status
+        "branch_status" => Vector{Bool}[],
+        "gen_status" => Vector{Bool}[],
     )
     for dataset_name in OPFs
         D[dataset_name] = Dict{String,Any}(
@@ -154,17 +152,16 @@ if abspath(PROGRAM_FILE) == @__FILE__
         rng = MersenneTwister(s)
         tgen = @elapsed data_ = rand(rng, opf_sampler)
         tsolve = @elapsed res = main(data_, config)
-        res["config"]["seed"] = s
 
         # Update input data
-        push!(D["input"]["meta"]["seed"], s)
-        push!(D["input"]["data"]["pd"], data_.pd)
-        push!(D["input"]["data"]["qd"], data_.qd)
-        push!(D["input"]["data"]["rmin"], data_.rmin)
-        push!(D["input"]["data"]["rmax"], data_.rmax)
-        push!(D["input"]["data"]["reserve_requirement"], data_.reserve_requirement)
-        push!(D["input"]["data"]["branch_status"], data_.branch_status)
-        push!(D["input"]["data"]["gen_status"], data_.gen_status)
+        push!(D["input"]["seed"], s)
+        push!(D["input"]["pd"], data_.pd)
+        push!(D["input"]["qd"], data_.qd)
+        push!(D["input"]["rmin"], data_.rmin)
+        push!(D["input"]["rmax"], data_.rmax)
+        push!(D["input"]["reserve_requirement"], data_.reserve_requirement)
+        push!(D["input"]["branch_status"], data_.branch_status)
+        push!(D["input"]["gen_status"], data_.gen_status)
 
         # Add output results, one for each OPF dataset
         for dataset_name in OPFs
@@ -182,9 +179,8 @@ if abspath(PROGRAM_FILE) == @__FILE__
     @info "All instances completed."
 
     # Tensorize everything in preparation for saving to disk
-    D["input"]["meta"]["seed"] = OPFGenerator.tensorize(D["input"]["meta"]["seed"])
-    for (k1, v1) in D["input"]["data"]
-        D["input"]["data"][k1] = OPFGenerator.tensorize(v1)
+    for (k1, v1) in D["input"]
+        D["input"][k1] = OPFGenerator.tensorize(v1)
     end
     for dataset_name in OPFs
         d = D[dataset_name]
@@ -192,7 +188,7 @@ if abspath(PROGRAM_FILE) == @__FILE__
             d[k1][k2] = OPFGenerator.tensorize(v2)
         end
         # Track random seed in dataset meta info, to simplify for post-processing
-        d["meta"]["seed"] = copy(D["input"]["meta"]["seed"])
+        d["meta"]["seed"] = copy(D["input"]["seed"])
     end
 
     # Save to disk in separate h5 files

--- a/exp/sampler.jl
+++ b/exp/sampler.jl
@@ -104,7 +104,7 @@ if abspath(PROGRAM_FILE) == @__FILE__
     @info "Floating-point data will be exported in `$(float_type)`"
 
     # Dummy run (for pre-compilation)
-    data0 = OPFGenerator.OPFData(make_basic_network(pglib("14_ieee")))
+    data0 = OPFGenerator.OPFData(make_basic_network(pglib("pglib_opf_case14_ieee")))
     opf_sampler0 = OPFGenerator.SimpleOPFSampler(data0, config["sampler"])
     rand!(MersenneTwister(1), opf_sampler0, data0)
     main(data0, config)

--- a/exp/sampler.jl
+++ b/exp/sampler.jl
@@ -74,9 +74,6 @@ end
 
 function main(data, config)
     d = Dict{String,Any}()
-    
-    # Keep track of input data
-    d["data"] = data
 
     for dataset_name in keys(config["OPF"])
         d[dataset_name] = build_and_solve_model(data, config, dataset_name)

--- a/slurm/make_ref.jl
+++ b/slurm/make_ref.jl
@@ -17,6 +17,7 @@ include("../exp/sampler.jl")
 
 d = main(data, config)
 d["data"] = OPFGenerator.to_dict(data)
+d["config"] = config
 
 mkpath(export_dir)
 OPFGenerator.save_json("$(export_dir)/case.json", d)

--- a/slurm/make_ref.jl
+++ b/slurm/make_ref.jl
@@ -5,19 +5,29 @@ using PGLib
 
 using OPFGenerator
 
-config_file = ARGS[1]
-config = TOML.parsefile(config_file)
-case_file, case_name = OPFGenerator._get_case_info(config)
-export_dir = pop!(config, "export_dir")
-pop!(config, "slurm")
+include(joinpath(@__DIR__, "..", "exp", "sampler.jl"))
 
-data = OPFGenerator.OPFData(make_basic_network(PowerModels.parse_file(case_file)))
+function main_ref(config; export_ref=false)
+    case_file, case_name = OPFGenerator._get_case_info(config)
+    export_dir = pop!(config, "export_dir")
+    pop!(config, "slurm")
 
-include("../exp/sampler.jl")
+    data = OPFGenerator.OPFData(make_basic_network(PowerModels.parse_file(case_file)))
 
-d = main(data, config)
-d["data"] = OPFGenerator.to_dict(data)
-d["config"] = config
+    d = main(data, config)
+    d["data"] = OPFGenerator.to_dict(data)
+    d["config"] = config
 
-mkpath(export_dir)
-OPFGenerator.save_json("$(export_dir)/case.json", d)
+    if export_ref
+        mkpath(export_dir)
+        OPFGenerator.save_json(joinpath(export_dir, "case.json"), d)
+    end
+    return d
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    config_file = ARGS[1]
+    config = TOML.parsefile(config_file)
+    main_ref(config; export_ref=true)
+    exit(0)
+end

--- a/slurm/make_ref.jl
+++ b/slurm/make_ref.jl
@@ -16,6 +16,7 @@ data = OPFGenerator.OPFData(make_basic_network(PowerModels.parse_file(case_file)
 include("../exp/sampler.jl")
 
 d = main(data, config)
+d["data"] = OPFGenerator.to_dict(data)
 
 mkpath(export_dir)
 OPFGenerator.save_json("$(export_dir)/case.json", d)

--- a/slurm/merge.jl
+++ b/slurm/merge.jl
@@ -30,7 +30,7 @@ function main(config::Dict)
         # _dedupe_and_sort_h5! expects the input dictionary to have a D["meta"]["seed"],
         #     so we artificially create this for input data...
         if dataset_name == "input"
-            D["meta"] = Dict("seed" => D["seed"])
+            D["meta"] = Dict("seed" => copy(D["seed"]))
         end
         OPFGenerator._dedupe_and_sort_h5!(D)
         # ... and delete it here

--- a/slurm/merge.jl
+++ b/slurm/merge.jl
@@ -51,6 +51,7 @@ function main(config::Dict)
         GC.gc()
     end
 
+    # Cleanup temp h5 files
     rm(joinpath(export_dir, "res_h5"), recursive=true)
 
     if "--no-split" in ARGS || get(slurm_config, "no_split", false)
@@ -94,35 +95,33 @@ function main(config::Dict)
     mkpath(joinpath(export_dir, "test"))
     mkpath(joinpath(export_dir, "infeasible"))
 
-    for opf in OPFs
-        for file in ["primal", "dual", "meta"]
-            h5open(joinpath(export_dir, opf, "$file.h5"), "r") do f
-                for (idx, split) in zip([train_idx, test_idx, infeasible_idx], ["train", "test", "infeasible"])
-                    mkpath(joinpath(export_dir, split, opf))
-                    h5open(joinpath(export_dir, split, opf, "$file.h5"), "w") do g
-                        for k in keys(f)
-                            val = read(f[k])
-                            g[k] = if k != "config" collect(selectdim(val, ndims(val), idx)) else val end
-                        end
-                    end
-                end
-            end
-            rm(joinpath(export_dir, opf, "$file.h5"))
-        end
-        rm(joinpath(export_dir, opf))
-    end
-    # same for input
-    h5open(joinpath(export_dir, "input.h5"), "r") do f
-        for (idx, split) in zip([train_idx, test_idx, infeasible_idx], ["train", "test", "infeasible"])
-            h5open(joinpath(export_dir, split, "input.h5"), "w") do g
-                for k in keys(f)
-                    val = read(f[k])
-                    g[k] = collect(selectdim(val, ndims(val), idx))
-                end
-            end
+    # g[k] = f[k][idx]  ∀ k ∈ keys(f)
+    function _copy_to_new_h5(g, f, idx)
+        for k in keys(f)
+            val = read(f[k])
+            g[k] = collect(selectdim(val, ndims(val), idx))
         end
     end
+
+    # Split consolidated H5s into train/test/infeasible sets
+    all_h5_paths = ["input"; [joinpath(opf, file) for opf in OPFs for file in ["primal", "dual", "meta"]]]
+    for (idx, split) in zip([train_idx, test_idx, infeasible_idx], ["train", "test", "infeasible"])
+        for p in all_h5_paths
+            src_path = joinpath(export_dir, p * ".h5")
+            h5open(src_path, "r") do f
+                dst_path = joinpath(export_dir, split, p * ".h5")
+                mkpath(dirname(dst_path))
+                h5open(dst_path, "w") do g
+                    _copy_to_new_h5(g, f, idx)
+                end  # close dst
+            end  # close src
+        end
+    end
+    # Cleanup workspace
     rm(joinpath(export_dir, "input.h5"))
+    for opf in OPFs
+        rm(joinpath(export_dir, opf), recursive=true)
+    end
 end
 
 if abspath(PROGRAM_FILE) == @__FILE__

--- a/slurm/merge.jl
+++ b/slurm/merge.jl
@@ -13,7 +13,6 @@ function main(config::Dict)
     all_h5_files = filter(endswith(".h5"), readdir(joinpath(export_dir, "res_h5"), join=true))
 
     slurm_config = pop!(config, "slurm")
-    config_str = JSON.json(config)
 
     # Process each dataset
     OPFs = sort(collect(keys(config["OPF"])))
@@ -28,12 +27,18 @@ function main(config::Dict)
         
         # Merge minibatches, sort, and export to disk
         D = OPFGenerator._merge_h5(Ds)
+        # _dedupe_and_sort_h5! expects the input dictionary to have a D["meta"]["seed"],
+        #     so we artificially create this for input data...
+        if dataset_name == "input"
+            D["meta"] = Dict("seed" => D["seed"])
+        end
         OPFGenerator._dedupe_and_sort_h5!(D)
+        # ... and delete it here
+        if dataset_name == "input"
+            delete!(D, "meta")
+        end
 
         # Save dataset to disk
-        get!(D, "meta", Dict{String,Any}())
-        D["meta"]["config"] = config_str
-
         if dataset_name == "input"
             OPFGenerator.save_h5(joinpath(export_dir, "input.h5"), D)
         else
@@ -110,16 +115,9 @@ function main(config::Dict)
     h5open(joinpath(export_dir, "input.h5"), "r") do f
         for (idx, split) in zip([train_idx, test_idx, infeasible_idx], ["train", "test", "infeasible"])
             h5open(joinpath(export_dir, split, "input.h5"), "w") do g
-                create_group(g, "data")
-                for k in keys(f["data"])
-                    val = read(f["data"][k])
-                    g["data"][k] = collect(selectdim(val, ndims(val), idx))
-                end
-
-                create_group(g, "meta")
-                for k in keys(f["meta"])
-                    val = read(f["meta"][k])
-                    g["meta"][k] = if k != "config" collect(selectdim(val, ndims(val), idx)) else val end
+                for k in keys(f)
+                    val = read(f[k])
+                    g[k] = collect(selectdim(val, ndims(val), idx))
                 end
             end
         end

--- a/test/sampler.jl
+++ b/test/sampler.jl
@@ -318,7 +318,8 @@ function test_sampler_script()
     # Check that input data file is structured as expected
     h5open(input_file_path, "r") do h5
         @test haskey(h5, "seed")
-        @test h5["seed"] == [1, 2, 3, 4]
+        @test size(h5["seed"]) == (4,)
+        @test eltype(h5["seed"]) == Int
 
         @test haskey(h5, "pd")
         @test size(h5["pd"]) == (11, 4)

--- a/test/sampler.jl
+++ b/test/sampler.jl
@@ -317,31 +317,32 @@ function test_sampler_script()
     @test isfile(input_file_path)
     # Check that input data file is structured as expected
     h5open(input_file_path, "r") do h5
-        @test haskey(h5, "data")
+        @test haskey(h5, "seed")
+        @test h5["seed"] == [1, 2, 3, 4]
 
-        @test haskey(h5["data"], "pd")
-        @test size(h5["data"]["pd"]) == (11, 4)
-        @test eltype(h5["data"]["pd"]) == Float64
-        @test haskey(h5["data"], "qd")
-        @test size(h5["data"]["pd"]) == (11, 4)
-        @test eltype(h5["data"]["qd"]) == Float64
+        @test haskey(h5, "pd")
+        @test size(h5["pd"]) == (11, 4)
+        @test eltype(h5["pd"]) == Float64
+        @test haskey(h5, "qd")
+        @test size(h5["pd"]) == (11, 4)
+        @test eltype(h5["qd"]) == Float64
 
-        @test haskey(h5["data"], "branch_status")
-        @test size(h5["data"]["branch_status"]) == (20, 4)
-        @test eltype(h5["data"]["branch_status"]) == Bool
-        @test haskey(h5["data"], "gen_status")
-        @test size(h5["data"]["gen_status"]) == (5, 4)
-        @test eltype(h5["data"]["gen_status"]) == Bool
+        @test haskey(h5, "branch_status")
+        @test size(h5["branch_status"]) == (20, 4)
+        @test eltype(h5["branch_status"]) == Bool
+        @test haskey(h5, "gen_status")
+        @test size(h5["gen_status"]) == (5, 4)
+        @test eltype(h5["gen_status"]) == Bool
 
-        @test haskey(h5["data"], "reserve_requirement")
-        @test size(h5["data"]["reserve_requirement"]) == (4,)
-        @test eltype(h5["data"]["reserve_requirement"]) == Float64
-        @test haskey(h5["data"], "rmin")
-        @test size(h5["data"]["rmin"]) == (5,4)
-        @test eltype(h5["data"]["rmin"]) == Float64
-        @test haskey(h5["data"], "rmax")
-        @test size(h5["data"]["rmax"]) == (5,4)
-        @test eltype(h5["data"]["rmax"]) == Float64
+        @test haskey(h5, "reserve_requirement")
+        @test size(h5["reserve_requirement"]) == (4,)
+        @test eltype(h5["reserve_requirement"]) == Float64
+        @test haskey(h5, "rmin")
+        @test size(h5["rmin"]) == (5,4)
+        @test eltype(h5["rmin"]) == Float64
+        @test haskey(h5, "rmax")
+        @test size(h5["rmax"]) == (5,4)
+        @test eltype(h5["rmax"]) == Float64
     end
 
     h5_paths = [


### PR DESCRIPTION
Addresses #166 

While doing this, I realized that our H5 sorting/de-duplicating helper functions assume an input dictionary that contains a valid `["meta"]["seed"]` key. 
The present changes (removing `"meta"` from the root of the input data dictionary) no longer satisfy that assumption when dealing with input data.

I had two ways around this issue:
1. manually add a `["meta"]["seed"]` key to the input data dictionary, process, then remove that key
2. update the lower-level functions to not require a `["meta"]["seed"]` key

I chose the first one because it required the least amount of code 😅